### PR TITLE
Implement Querying for Documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [NEW] New FindDocumentsOperation API.
+
 # 0.2.1 (2016-05-13)
 
 - [FIX] Fixed compatibility with Swift Development Snapshot from 2016-05-09

--- a/Source/FindDocumentsOperation.swift
+++ b/Source/FindDocumentsOperation.swift
@@ -1,0 +1,253 @@
+//
+//  FindDocumentsOperation.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 20/04/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ The direction of Sorting
+ */
+public enum SortDirection: String {
+    /**
+     Sort ascending
+     */
+    case Asc = "asc"
+    /**
+     Sort descending
+     */
+    case Desc = "desc"
+}
+
+/**
+ Specfies how a field should be sorted
+ */
+public struct Sort {
+
+    /**
+     The field on which to sort
+     */
+    let field: String
+    let sort: SortDirection?
+}
+
+/**
+ Usage example:
+
+ ```
+ let find = FindDocumentsOperation()
+ find.selector = ["foo":"bar"]
+ find.fields = ["foo"]
+ find.sort = [Sort(field: "foo", sort: .Desc)]
+ find.documentFoundHanlder = { (document) in
+    // Do something with the document.
+ }
+ find.completionHandler = {(response, httpInfo, error) in
+    if let error = error {
+        // handle the error.
+    } else {
+        // do something on success.
+    }
+ }
+ database.add(operation:find)
+ 
+ ```
+ */
+public class FindDocumentsOperation: CouchDatabaseOperation {
+    /**
+     The selector for the query, as a dictionary representation. See
+     [the Cloudant documentation](https://docs.cloudant.com/cloudant_query.html#selector-syntax)
+     for syntax information.
+
+     Required: This needs to be set before the operation can successfully run.
+     */
+    public var selector: [String: AnyObject]?;
+
+    /**
+     The fields to include in the results.
+
+     - Note: Optional: if the property is unset this parameter will
+     not be included in the request and the server default will apply.
+     */
+    public var fields: [String]?
+
+    /**
+     The number maximium number of documents to return.
+
+     - Note: Optional, if the property is unset this parameter will
+      not be included in the request and the server default will apply.
+     */
+    public var limit: Int?
+
+    /**
+     Skip the first _n_ results, where _n_ is specified by skip.
+
+     - Note: Optional, if the property is unset this parameter will not be
+     included in the request and the server default will apply.
+     */
+    public var skip: Int?
+
+    /**
+     An array that indicates how to sort the results.
+     
+     - SeeAlso: [Query sort syntax](https://docs.cloudant.com/cloudant_query.html#sort-syntax)
+
+     - Note: Optional, if the property is unset this parameter will not be included
+     in the request and the server default will apply.
+     */
+    public var sort: [Sort]?
+
+    /**
+     A string that enables you to specify which page of results you require.
+
+     - Note: Optional, if the property is unset this parameter will not be included
+     in the request and the server default will apply.
+
+     - Remark: This is only valid for text indexes.
+     */
+    public var bookmark: String?
+
+    /**
+     A specific index to run the query against.
+
+     - Note: Optional, if the property is unset this parameter will not be
+     included in the request and the server default will apply.
+     */
+    public var useIndex: String?
+
+    /**
+     The read quorum for this request.
+
+     - Note: Optional, if the property is unset this parameter will not be included
+     in the request and the server default will apply.
+
+     - warning: This is an advanced option and is rarely, if ever, needed. It will be detrimental to
+     performance.
+
+     */
+    public var r: Int?
+
+    /**
+     Handler to run for each document retrived from the database matching the query.
+
+     - parameter document: a document matching the query.
+     */
+    public var documentFoundHanlder: ((document: [String: AnyObject]) -> Void)?
+
+    private var json: [String: AnyObject]?
+
+    public override var httpMethod: String {
+        return "POST"
+    }
+
+    public override var httpPath: String {
+        return "/\(self.databaseName!)/_find"
+    }
+
+    private var jsonData: NSData?
+    public override var httpRequestBody: NSData? {
+        return self.jsonData
+    }
+
+    public override func validate() -> Bool {
+        if !super.validate() {
+            return false
+        }
+        
+        if self.selector == nil {
+            return false
+        }
+
+        let jsonObj = createJsonDict()
+        if NSJSONSerialization.isValidJSONObject(jsonObj as NSDictionary) {
+            self.json = jsonObj
+            return true
+        } else {
+            return false;
+        }
+    }
+    
+    private func createJsonDict() -> [String: AnyObject] {
+        // build the body dict, we will store this to save compute cycles.
+        var jsonObj: [String: AnyObject] = [:]
+        
+        if let selector = self.selector {
+            jsonObj["selector"] = selector as NSDictionary
+        }
+        
+        if let limit = self.limit {
+            jsonObj["limit"] = limit as NSNumber
+        }
+        
+        if let skip = self.skip {
+            jsonObj["skip"] = skip as NSNumber
+        }
+        
+        if let r = self.r {
+            jsonObj["r"] = r as NSNumber
+        }
+        
+        if let sort = self.sort {
+            jsonObj["sort"] = transform(sortArray: sort) as NSArray
+        }
+        
+        if let fields = self.fields {
+            jsonObj["fields"] = fields as NSArray
+        }
+        
+        if let bookmark = self.bookmark {
+            jsonObj["bookmark"] = bookmark as NSString
+        }
+        
+        if let useIndex = self.useIndex {
+            jsonObj["use_index"] = useIndex as NSString
+        }
+
+        return jsonObj
+    }
+
+    private func transform(sortArray: [Sort]) -> [AnyObject] {
+
+        var transfomed: [AnyObject] = []
+        for s in sortArray {
+            if let sort = s.sort {
+                let dict = [s.field: sort.rawValue]
+                transfomed.append(dict as NSDictionary)
+            } else {
+                transfomed.append(s.field as NSString)
+            }
+        }
+
+        return transfomed
+    }
+
+    public override func serialise() throws {
+        
+        if self.json == nil {
+            self.json = createJsonDict()
+        }
+ 
+        if let json = self.json {
+            self.jsonData = try NSJSONSerialization.data(withJSONObject: json as NSDictionary)
+        }
+    }
+
+    public override func processResponse(json: [String: AnyObject]) {
+        if let docs = json["docs"] as? [[String: AnyObject]] { // Array of [String:AnyObject]
+            for doc: [String: AnyObject] in docs {
+                self.documentFoundHanlder?(document: doc)
+            }
+        }
+    }
+}

--- a/SwiftCloudant.xcodeproj/project.pbxproj
+++ b/SwiftCloudant.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		9855CF7F1CC6459E00ED28DA /* GetDocumentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF781CC6459E00ED28DA /* GetDocumentOperation.swift */; };
 		9855CF801CC6459E00ED28DA /* PutDocumentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF791CC6459E00ED28DA /* PutDocumentOperation.swift */; };
 		9855CF861CC8CE5F00ED28DA /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */; };
+		9855CF821CC7C5D100ED28DA /* FindDocumentsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF811CC7C5D100ED28DA /* FindDocumentsOperation.swift */; };
+		9855CF841CC7E3DB00ED28DA /* FindDocumentOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF831CC7E3DB00ED28DA /* FindDocumentOperationTests.swift */; };
 		98734A211C88FDB200E79C5B /* SwiftCloudant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98734A171C88FDB200E79C5B /* SwiftCloudant.framework */; };
 		98734A4F1C8A600600E79C5B /* CouchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A401C8A600600E79C5B /* CouchClient.swift */; };
 		98734A501C8A600600E79C5B /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A411C8A600600E79C5B /* Database.swift */; };
@@ -62,6 +64,8 @@
 		9855CF781CC6459E00ED28DA /* GetDocumentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GetDocumentOperation.swift; path = Source/GetDocumentOperation.swift; sourceTree = SOURCE_ROOT; };
 		9855CF791CC6459E00ED28DA /* PutDocumentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PutDocumentOperation.swift; path = Source/PutDocumentOperation.swift; sourceTree = SOURCE_ROOT; };
 		9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		9855CF811CC7C5D100ED28DA /* FindDocumentsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FindDocumentsOperation.swift; path = Source/FindDocumentsOperation.swift; sourceTree = SOURCE_ROOT; };
+		9855CF831CC7E3DB00ED28DA /* FindDocumentOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindDocumentOperationTests.swift; sourceTree = "<group>"; };
 		98734A171C88FDB200E79C5B /* SwiftCloudant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCloudant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98734A201C88FDB200E79C5B /* SwiftCloudantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCloudantTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		98734A401C8A600600E79C5B /* CouchClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouchClient.swift; sourceTree = "<group>"; };
@@ -147,6 +151,7 @@
 			isa = PBXGroup;
 			children = (
 				2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */,
+				9855CF811CC7C5D100ED28DA /* FindDocumentsOperation.swift */,
 				9855CF731CC6459E00ED28DA /* CouchDatabaseOperation.swift */,
 				9855CF741CC6459E00ED28DA /* CouchOperation.swift */,
 				9855CF751CC6459E00ED28DA /* CreateDatabaseOperation.swift */,
@@ -171,6 +176,7 @@
 				98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */,
 				9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */,
 				98FAABBD1CD89F7D0087FF57 /* TestSettings.plist */,
+				9855CF831CC7E3DB00ED28DA /* FindDocumentOperationTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -367,6 +373,7 @@
 				98734A501C8A600600E79C5B /* Database.swift in Sources */,
 				98734A4F1C8A600600E79C5B /* CouchClient.swift in Sources */,
 				9855CF7E1CC6459E00ED28DA /* DeleteDocumentOperation.swift in Sources */,
+				9855CF821CC7C5D100ED28DA /* FindDocumentsOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -381,6 +388,7 @@
 				98734A611C8A601400E79C5B /* CreateDatabaseTests.swift in Sources */,
 				98734A621C8A601400E79C5B /* GetDocumentTests.swift in Sources */,
 				98734A641C8A601400E79C5B /* SwiftCloudantTests.swift in Sources */,
+				9855CF841CC7E3DB00ED28DA /* FindDocumentOperationTests.swift in Sources */,
 				98E5431C1C9CCD0500F02E06 /* InterceptorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/FindDocumentOperationTests.swift
+++ b/Tests/FindDocumentOperationTests.swift
@@ -1,0 +1,343 @@
+//
+//  FindDocumentOperationTests.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 20/04/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import XCTest
+import OHHTTPStubs
+@testable import SwiftCloudant
+
+class FindDocumentOperationTests: XCTestCase {
+    var client: CouchDBClient? = nil;
+    var dbName: String? = nil
+    var db: Database? = nil
+    
+    
+    override func setUp() {
+        super.setUp()
+        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            return (request.url?.path?.contains("_find"))! && request.httpMethod == "POST"
+            } , withStubResponse: { (request) -> OHHTTPStubsResponse in
+            return OHHTTPStubsResponse(jsonObject: [    "docs" : [
+                                                                     [
+                                                                         "_id" : "2",
+                                                                         "_rev" : "1-9f0e70c7592b2e88c055c51afc2ec6fd",
+                                                                         "foo" : "test",
+                                                                         "bar" : 2600000
+                ],
+                                                                     [
+                                                                         "_id" : "1",
+                                                                         "_rev" : "1-026418c17a353a9b73a6ccac19c142a4",
+                                                                         "foo" : "another test",
+                                                                         "bar" : 9800000
+                ]
+                ]], statusCode: 200, headers: [:])
+        })
+        
+            OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+                return (request.url?.path?.contains("_find"))! && !(request.httpMethod! == "POST")
+                }, withStubResponse: { (request) -> OHHTTPStubsResponse in
+                    OHHTTPStubsResponse(jsonObject: [], statusCode: 405, headers: [:])
+            })
+        
+        dbName = generateDBName()
+        client = CouchDBClient(url: NSURL(string:self.url)!, username: self.username, password: self.password)
+        db = client![dbName!]
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        OHHTTPStubs.removeAllStubs()
+    }
+
+    
+    func testInvalidSelector() {
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":find]
+        
+        let expectation = self.expectation(withDescription: "invalidSelector")
+        
+        find.completionHandler = { (response, httpInfo, error) in
+            XCTAssertNil(response)
+            XCTAssertNil(httpInfo)
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+
+        db?.add(operation: find)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+        
+    }
+    
+    func testCanQueryDocsOnlySelector() {
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":"bar"]
+        
+        let firstDocExpectation = self.expectation(withDescription: "1st Doc result")
+        let secondDocExpectation = self.expectation(withDescription: "2nd doc result")
+        let operationComplete = self.expectation(withDescription: "Operation Complete")
+        
+        var first = true
+        
+        find.documentFoundHanlder = {(document) in
+            if first {
+                first = false
+                firstDocExpectation.fulfill()
+            } else {
+                secondDocExpectation.fulfill()
+            }
+            
+            XCTAssertNotNil(document)
+            // Assert that each document contains 4 JSON properties.
+            XCTAssertEqual(4, document.count)
+        }
+        
+        find.completionHandler = { (response, httpInfo, error) in
+            XCTAssertNotNil(response)
+            XCTAssertNil(response?["bookmark"])
+            XCTAssertNotNil(httpInfo)
+            XCTAssertNil(error)
+            operationComplete.fulfill()
+            
+        }
+        
+        db?.add(operation: find)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+
+    }
+    
+    func testCanQueryDocsAllValuesSet() {
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":"bar"]
+        find.fields = ["foo","bar"]
+        find.limit = 26
+        find.skip = 1
+        find.sort = [Sort(field: "foo", sort: nil)]
+        find.bookmark = "blah"
+        find.useIndex = "anIndex"
+        find.r = 1
+        
+        let expectation = self.expectation(withDescription: "Find op with all the options")
+        find.completionHandler = { (response, httpInfo, error) in
+            XCTAssertNotNil(response)
+            XCTAssertNil(response?["bookmark"])
+            XCTAssertNotNil(httpInfo)
+            XCTAssertNil(error)
+            expectation.fulfill()
+            
+        }
+        
+        db?.add(operation: find)
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testOperationRequestPayload() throws {
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":"bar"]
+        find.fields = ["foo","bar"]
+        find.limit = 26
+        find.skip = 1
+        find.sort = [Sort(field: "foo", sort: nil)]
+        find.bookmark = "blah"
+        find.useIndex = "anIndex"
+        find.r = 1
+        find.databaseName = self.dbName
+        
+        
+        XCTAssert(find.validate())
+        try find.serialise()
+        XCTAssertEqual("/\(dbName!)/_find", find.httpPath)
+        XCTAssertEqual("POST", find.httpMethod)
+        let httpBodyOpt = find.httpRequestBody
+        XCTAssertNotNil(httpBodyOpt)
+        
+        if let httpBody = httpBodyOpt {
+        
+            do {
+                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                
+                let expected:[String:NSObject] = ["selector":["foo":"bar"],
+                                "fields":["foo","bar"],
+                                "limit": 26,
+                                "skip": 1,
+                                "sort": ["foo"],
+                                "bookmark": "blah",
+                                "use_index":"anIndex",
+                                "r": 1
+                                ]
+                
+                if let json = json {
+                    XCTAssertEqual(expected , json, "Expected: \(expected) but was \(json)")
+               } else {
+                   XCTFail("Json could not be deseralised to the type [String:AnyObject]")
+                }
+            
+            } catch {
+                XCTFail("Error deserialising json: \(error)")
+            }
+        }
+    }
+    
+    func testOperationRequestWithSortDirectionAsc() throws {
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":"bar"]
+        find.sort = [Sort(field: "foo", sort: .Asc)]
+        find.databaseName = self.dbName
+        
+        
+        XCTAssert(find.validate())
+        try find.serialise()
+        XCTAssertEqual("/\(dbName!)/_find", find.httpPath)
+        XCTAssertEqual("POST", find.httpMethod)
+        let httpBodyOpt = find.httpRequestBody
+        XCTAssertNotNil(httpBodyOpt)
+        
+        if let httpBody = httpBodyOpt {
+            
+            do {
+                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                
+                let expected:[String:NSObject] = ["selector":["foo":"bar"],
+                                                  "sort": [["foo":"asc"]],
+                ]
+                
+                if let json = json {
+                    XCTAssertEqual(expected , json, "Expected: \(expected) but was \(json)")
+                } else {
+                    XCTFail("Json could not be deseralised to the type [String:AnyObject]")
+                }
+                
+            } catch {
+                XCTFail("Error deserialising json: \(error)")
+            }
+        }
+    }
+    
+    func testOperationRequestWithSortDirectionDesc() throws {
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":"bar"]
+        find.sort = [Sort(field: "foo", sort: .Desc)]
+        find.databaseName = self.dbName
+        
+        
+        XCTAssert(find.validate())
+        try find.serialise()
+        XCTAssertEqual("/\(dbName!)/_find", find.httpPath)
+        XCTAssertEqual("POST", find.httpMethod)
+        let httpBodyOpt = find.httpRequestBody
+        XCTAssertNotNil(httpBodyOpt)
+        
+        if let httpBody = httpBodyOpt {
+            
+            do {
+                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                
+                let expected:[String:NSObject] = ["selector":["foo":"bar"],
+                                                  "sort": [["foo":"desc"]],
+                                                  ]
+                
+                if let json = json {
+                    XCTAssertEqual(expected , json, "Expected: \(expected) but was \(json)")
+                } else {
+                    XCTFail("Json could not be deseralised to the type [String:AnyObject]")
+                }
+                
+            } catch {
+                XCTFail("Error deserialising json: \(error)")
+            }
+        }
+    }
+    
+    func testBookmarkReturnedFromTextQuery() {
+        
+        OHHTTPStubs.removeAllStubs() // Remove stubs, we just want a custom one for now
+        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            if let retvar = request.url?.path?.contains("_find") {
+                return retvar
+            } else {
+                return false
+            }
+            }, withStubResponse: { (request) -> OHHTTPStubsResponse in
+                return OHHTTPStubsResponse(jsonObject: ["bookmark":"blah", "docs":[]], statusCode: 200, headers: [:])
+        })
+    
+        
+        
+        
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":"bar"]
+        find.fields = ["foo","bar"]
+        find.limit = 26
+        find.skip = 1
+        find.sort = [Sort(field: "foo", sort: nil)]
+        find.bookmark = "blah"
+        find.useIndex = "anIndex"
+        find.r = 1
+        
+        let expectation = self.expectation(withDescription: "Find op with all the options")
+        find.completionHandler = { (response, httpInfo, error) in
+            XCTAssertNotNil(response)
+            XCTAssertEqual("blah", response?["bookmark"] as? String)
+            XCTAssertNotNil(httpInfo)
+            XCTAssertNil(error)
+            expectation.fulfill()
+            
+        }
+        
+        db?.add(operation: find)
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testValuesOmittedIfNotSet() throws {
+        let find = FindDocumentsOperation()
+        find.selector = ["foo":"bar"]
+        find.databaseName = self.dbName
+        XCTAssert(find.validate())
+        try find.serialise()
+        
+
+        
+        XCTAssertEqual("/\(dbName!)/_find", find.httpPath)
+        XCTAssertEqual("POST", find.httpMethod);
+        let httpBodyOpt = find.httpRequestBody
+        XCTAssertNotNil(httpBodyOpt)
+        
+        if let httpBody = httpBodyOpt {
+            
+            do {
+                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                
+                let expected:[String:NSObject] = ["selector":["foo":"bar"]]
+                
+                if let json = json {
+                    XCTAssertEqual(expected , json, "Expected: \(expected) but was \(json)")
+                } else {
+                    XCTFail("Json could not be deseralised to the type [String:AnyObject]")
+                }
+                
+            } catch {
+                XCTFail("Error deserialising json: \(error)")
+            }
+        }
+        
+        
+        
+        
+        
+        
+    }
+
+}


### PR DESCRIPTION
## What
Support Querying for documents using the `_find` endpoint.

##  How
- Created FindDocumentsOperation which represents an operation to find documents using the `_find` endpoint.

## Testing
New test case added: FindDocumentsOperationTests, this contains the following:
- Extensive testing against a Mocked HTTP response using `OHHTTPStubs` 
- Tests to make sure properties return values expected, eg `POST` for HTTP method the body being sent is correct etc.

## Reviewers
reviewer @ricellis

## Issues
Fixes #8