### PR TITLE
34 view query op

### DIFF
--- a/Source/CouchDatabaseOperation.swift
+++ b/Source/CouchDatabaseOperation.swift
@@ -25,4 +25,8 @@ public class CouchDatabaseOperation : CouchOperation {
      The name of the database the operation is operating on.
      */
     public var databaseName: String?
+    
+    override public func validate() -> Bool {
+        return super.validate() && databaseName != nil
+    }
 }

--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -61,6 +61,10 @@ enum Errors : ErrorProtocol {
      The JSON format wasn't what we expected.
      */
     case UnexpectedJSONFormat(statusCode:Int, response:String?)
+    /**
+     The query view operation failed.
+    */
+    case QueryViewFailed(statusCode: Int, response: String?)
 };
 
 /**

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -1,0 +1,377 @@
+//
+//  QueryViewOperation.swift
+//  SwiftCloudant
+//
+//
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ 
+ An operation to query a view.
+ 
+ - Requires: the `designDoc` and `viewName` properties must be set on this operation.
+ 
+ Example usage:
+ ```
+ let view = QueryViewOperation()
+ view.dbName = "example"
+ view.designDoc = "exampleDesignDoc"
+ view.viewName = "exampleView"
+ 
+ // Set a row handler to process each returned row
+ view.rowHandler = {(row) in
+     // Do something with row JSON
+     // Example: get the value
+     row["value"]
+ }
+ 
+ // Set a completion handler to get a callback 
+ // when the operation finishes
+ view.queryViewCompletionHandler = {(error) in
+     if error != nil {
+     // Example: handle an error by printing a message
+     print("Error")
+     }
+ }
+ 
+ // Add the operation to the database operation queue
+ database.add(view)
+ ```
+ */
+public class QueryViewOperation: CouchDatabaseOperation {
+    
+    /**
+     The name of the design document which contains the view.
+     
+     - Note: must be set for a query view operation to successfully run.
+     */
+    public var designDoc: String? = nil
+    
+    /**
+     The name of the view to query.
+     
+     - Note: must be set for a query view operation to successfully run.
+     */
+    public var viewName: String? = nil
+    
+    /**
+     Return the result rows in 'descending by key' order.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var descending: Bool? = nil
+    
+    /**
+     Return key/value result rows starting from the specified key.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var startKey: AnyObject? = nil
+    
+    /**
+     Used in conjunction with startKey to further restrict the starting row for
+     cases where two documents emit the same key. Specifying the doc ID allows
+     the view to return result rows from the specified start key and document.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var startKeyDocId: String? = nil
+    
+    /**
+     Stop the view returning result rows when the specified key is reached.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var endKey: AnyObject? = nil
+    
+    /**
+     Used in conjunction with endKey to further restrict the ending row for cases
+     where two documents emit the same key. Specifying the doc ID allows the view
+     to return result rows up to the specified end key and document.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var endKeyDocId: String? = nil
+    
+    /**
+     Include result rows with the specified `endKey`.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var inclusiveEnd: Bool? = nil
+    
+    /**
+     Return only result rows that match the specified key.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     
+     - Warning: Cannot be used with `keys` option.
+     */
+    public var key: AnyObject? = nil
+    
+    /**
+     Return only result rows that match the specified keys.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     
+     - Warning: Cannot be used with `key` option.
+     */
+    public var keys: Array<AnyObject>? = nil
+    
+    /**
+     Limit the number of result rows returned from the view.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var limit: Int? = nil
+    
+    /**
+     The number of rows to skip in the view results.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var skip: Int? = nil
+    
+    /**
+     Include the full content of documents in the view results.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var includeDocs: Bool? = nil
+    
+    /**
+     Use the reduce function for the view.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    public var reduce: Bool? = nil
+    
+    /**
+     Group the results of a reduce based on their keys.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     
+     - Warning: Only valid when a `reduce` function is used.
+     */
+    public var group: Bool? = nil
+    
+    /**
+     Control view aggregation of complex keys by setting the number of elements of the key array to use for grouping reduce results.
+     
+     For example, if the view emits complex keys of the form `["A", "B", "C"]` and is using a `_count` reduce function then setting `groupLevel` would have these effects:
+     * `view.groupLevel = 3` would produce rows of the form `{ "key" : ["A", "B", "C"], "value" : n }` where `n` is the count of documents with key `["A", "B", "C"]
+     * `view.groupLevel = 1` would produces rows of the form `{ "key" : ["A"], "value" : m }` where `m` is the aggregated count of all keys with "A" as the first element
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     
+     - Warning: Only valid if `group` is `true`
+     */
+    public var groupLevel: Int? = nil
+    
+    /**
+     Acceptable values for allowing stale views with the `stale` property. To disallow stale views use the default `stale=nil`.
+     */
+    public enum Stale: CustomStringConvertible {
+        /// Allow stale views.
+        case Ok
+        /// Allow stale views, but update them immediately after the request.
+        case UpdateAfter
+        
+        public var description: String {
+            switch self {
+            case .Ok: return "ok"
+            case .UpdateAfter: return "update_after"
+            }
+        }
+    }
+    
+    /**
+     Configures the view request to allow the return of stale results, that is allowing the view to return immediately rather than waiting for the view index to build. When this parameter is omitted (i.e. with the default of `stale=nil`) the server will not return stale results.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     - SeeAlso: `Stale` for descriptions of the available values for allowing stale views.
+     - Warning: This is an advanced option, it should not be used unless you fully understand the outcome of changing the value of this property.
+     */
+    public var stale: Stale? = nil
+    
+    /**
+     Sets a completion handler to run when the operation completes.
+     
+     - parameter error: - ErrorProtocol instance with information about an error executing the operation
+     */
+    public var queryViewCompletionHandler: ((error: ErrorProtocol?) -> Void)?
+    
+    /**
+     Sets a handler to run for each row retrieved by the view.
+     
+     - parameter row: dictionary of the JSON data from the view row
+     */
+    public var rowHandler: ((row: [String:AnyObject]) -> Void)?
+    
+    public override func validate() -> Bool {
+        // Design doc and view name must be set
+        if designDoc == nil || viewName == nil {
+            return false
+        }
+        // Only one of key or keys can be used
+        if key != nil && keys != nil {
+            return false
+        }
+        if reduce != nil && !reduce! {
+            // reduce=false, check that group and groupLevel are not used
+            if group != nil || groupLevel != nil {
+                return false
+            }
+        } else {
+            // reduce=true, check that group level is not specified without group
+            if !(group != nil && group!) && groupLevel != nil {
+                return false
+            }
+        }
+        return super.validate()
+    }
+    
+    public override var httpMethod: String {
+        if (keys != nil) {
+            return "POST"
+        } else {
+            return "GET"
+        }
+    }
+    
+    public override var httpRequestBody: NSData? {
+        if let keys = keys {
+            do {
+                let keysJson = try NSJSONSerialization.data(withJSONObject: ["keys": keys])
+                return keysJson
+            } catch {
+                callCompletionHandler(error: error)
+            }
+        }
+        return nil
+    }
+    
+    public override var httpPath: String {
+        return "/\(self.databaseName!)/_design/\(designDoc!)/_view/\(viewName!)"
+    }
+    
+    public override var queryItems: [NSURLQueryItem] {
+        get {
+            var items: [NSURLQueryItem] = []
+            
+            if let descending = descending {
+                items.append(NSURLQueryItem(name: "descending", value: "\(descending)"))
+            }
+            
+            if let startKey = startKey {
+                items.append(NSURLQueryItem(name: "startkey", value: convertJson(key: startKey)))
+            }
+            
+            if let startKeyDocId = startKeyDocId {
+                items.append(NSURLQueryItem(name: "startkey_docid", value: "\(startKeyDocId)"))
+            }
+            
+            if let endKey = endKey {
+                items.append(NSURLQueryItem(name: "endkey", value: convertJson(key: endKey)))
+            }
+            
+            if let endKeyDocId = endKeyDocId {
+                items.append(NSURLQueryItem(name: "endkey_docid", value: "\(endKeyDocId)"))
+            }
+            
+            if let inclusiveEnd = inclusiveEnd {
+                items.append(NSURLQueryItem(name: "inclusive_end", value: "\(inclusiveEnd)"))
+            }
+            
+            if let key = key {
+                items.append(NSURLQueryItem(name: "key", value: convertJson(key: key)))
+            }
+            
+            if let limit = limit {
+                items.append(NSURLQueryItem(name: "limit", value: "\(limit)"))
+            }
+            
+            if let skip = skip {
+                items.append(NSURLQueryItem(name: "skip", value: "\(skip)"))
+            }
+            
+            if let includeDocs = includeDocs {
+                items.append(NSURLQueryItem(name: "include_docs", value: "\(includeDocs)"))
+            }
+            
+            if let reduce = reduce {
+                items.append(NSURLQueryItem(name: "reduce", value: "\(reduce)"))
+            }
+            
+            if let group = group {
+                items.append(NSURLQueryItem(name: "group", value: "\(group)"))
+            }
+            
+            if let groupLevel = groupLevel {
+                items.append(NSURLQueryItem(name: "group_level", value: "\(groupLevel)"))
+            }
+            
+            if let stale = stale {
+                items.append(NSURLQueryItem(name: "stale", value: "\(stale)"))
+            }
+            
+            return items
+        }
+    }
+    
+    public override func callCompletionHandler(error: ErrorProtocol) {
+        self.queryViewCompletionHandler?(error: error)
+    }
+    
+    public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
+        if let error = error {
+            self.callCompletionHandler(error:error)
+            return
+        }
+        
+        // Check status code is 200
+        if statusCode == 200 {
+            do {
+                let json = try NSJSONSerialization.jsonObject(with: data!)
+                let rows = json["rows"] as! [[String:AnyObject]]
+                for row:[String:AnyObject] in rows {
+                    self.rowHandler?(row: row)
+                }
+                self.queryViewCompletionHandler?(error: nil)
+            } catch {
+                callCompletionHandler(error: error)
+            }
+        } else {
+            callCompletionHandler(error: Errors.QueryViewFailed(statusCode: statusCode, response: String(data, NSUTF8StringEncoding)))
+        }
+    }
+    
+    func convertJson(key: AnyObject) -> String {
+        if NSJSONSerialization.isValidJSONObject(key) {
+            do {
+                let keyJson = try NSJSONSerialization.data(withJSONObject: key)
+                return String(data: keyJson , encoding: NSUTF8StringEncoding)!
+            } catch {
+                callCompletionHandler(error: error)
+                return ""
+            }
+        } else if key is String {
+            // we need to quote JSON primitive strings
+            return "\"\(key)\""
+        } else {
+            // anything else we just try as stringified JSON value
+            return "\(key)"
+        }
+    }
+}

--- a/SwiftCloudant.xcodeproj/project.pbxproj
+++ b/SwiftCloudant.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		2C4B910F7FFAC8132F5280BB /* Pods_SwiftCloudantTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F96FB133EC7F68F6BF31CC3 /* Pods_SwiftCloudantTests.framework */; };
+		2E79FE9C1CDA2BF500AD20E2 /* QueryViewOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */; };
+		2E79FE9E1CDA2C0900AD20E2 /* QueryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E79FE9D1CDA2C0900AD20E2 /* QueryViewTests.swift */; };
 		9855CF6F1CC6458F00ED28DA /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6B1CC6458F00ED28DA /* RequestBuilder.swift */; };
 		9855CF701CC6458F00ED28DA /* RequestExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6C1CC6458F00ED28DA /* RequestExecutor.swift */; };
 		9855CF711CC6458F00ED28DA /* SessionCookieInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6D1CC6458F00ED28DA /* SessionCookieInterceptor.swift */; };
@@ -45,6 +47,8 @@
 
 /* Begin PBXFileReference section */
 		05340EE0F16E4C566C32FD41 /* Pods-SwiftCloudantTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftCloudantTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftCloudantTests/Pods-SwiftCloudantTests.release.xcconfig"; sourceTree = "<group>"; };
+		2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = QueryViewOperation.swift; path = Source/QueryViewOperation.swift; sourceTree = SOURCE_ROOT; };
+		2E79FE9D1CDA2C0900AD20E2 /* QueryViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryViewTests.swift; sourceTree = "<group>"; };
 		7F96FB133EC7F68F6BF31CC3 /* Pods_SwiftCloudantTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftCloudantTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9855CF6B1CC6458F00ED28DA /* RequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestBuilder.swift; path = Source/RequestBuilder.swift; sourceTree = SOURCE_ROOT; };
 		9855CF6C1CC6458F00ED28DA /* RequestExecutor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestExecutor.swift; path = Source/RequestExecutor.swift; sourceTree = SOURCE_ROOT; };
@@ -142,6 +146,7 @@
 		98734A481C8A600600E79C5B /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */,
 				9855CF731CC6459E00ED28DA /* CouchDatabaseOperation.swift */,
 				9855CF741CC6459E00ED28DA /* CouchOperation.swift */,
 				9855CF751CC6459E00ED28DA /* CreateDatabaseOperation.swift */,
@@ -156,6 +161,7 @@
 		98734A5C1C8A601400E79C5B /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				2E79FE9D1CDA2C0900AD20E2 /* QueryViewTests.swift */,
 				98EC4AE61CC1531200704CFE /* DeleteDocumentTests.swift */,
 				98734A5D1C8A601400E79C5B /* CreateDatabaseTests.swift */,
 				98734A5E1C8A601400E79C5B /* GetDocumentTests.swift */,
@@ -354,6 +360,7 @@
 				9855CF701CC6458F00ED28DA /* RequestExecutor.swift in Sources */,
 				9855CF7B1CC6459E00ED28DA /* CouchOperation.swift in Sources */,
 				9855CF711CC6458F00ED28DA /* SessionCookieInterceptor.swift in Sources */,
+				2E79FE9C1CDA2BF500AD20E2 /* QueryViewOperation.swift in Sources */,
 				9855CF801CC6459E00ED28DA /* PutDocumentOperation.swift in Sources */,
 				9855CF7A1CC6459E00ED28DA /* CouchDatabaseOperation.swift in Sources */,
 				9855CF6F1CC6458F00ED28DA /* RequestBuilder.swift in Sources */,
@@ -370,6 +377,7 @@
 				98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */,
 				98EC4AE81CC1533800704CFE /* DeleteDocumentTests.swift in Sources */,
 				9855CF861CC8CE5F00ED28DA /* TestHelpers.swift in Sources */,
+				2E79FE9E1CDA2C0900AD20E2 /* QueryViewTests.swift in Sources */,
 				98734A611C8A601400E79C5B /* CreateDatabaseTests.swift in Sources */,
 				98734A621C8A601400E79C5B /* GetDocumentTests.swift in Sources */,
 				98734A641C8A601400E79C5B /* SwiftCloudantTests.swift in Sources */,

--- a/Tests/PutDocumentTests.swift
+++ b/Tests/PutDocumentTests.swift
@@ -31,6 +31,10 @@ class PutDocumentTests : XCTestCase {
         createDatabase(databaseName: dbName!, client: client!)
     }
     
+    override func tearDown() {
+        deleteDatabase(databaseName: dbName!, client: client!)
+        super.tearDown()
+    }
     
     func testSaveDocument(){
         let db = self.client![self.dbName!]

--- a/Tests/QueryViewTests.swift
+++ b/Tests/QueryViewTests.swift
@@ -1,0 +1,369 @@
+//
+//  QueryViewTests.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 25/04/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+import XCTest
+import OHHTTPStubs
+@testable import SwiftCloudant
+
+public class QueryViewTests : XCTestCase {
+    
+    var dbName: String? = nil
+    var client: CouchDBClient?
+    
+    override public func setUp() {
+        super.setUp()
+        dbName = generateDBName()
+        client = CouchDBClient(url: NSURL(string:url)!, username: username, password: password)
+        
+        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            return (request.url?.path?.contains("/_view/"))!
+            }, withStubResponse: { (response) -> OHHTTPStubsResponse in
+                return OHHTTPStubsResponse(jsonObject: [ "offset" : 0,
+                                                         "rows" : [ [ "id" : "3-tiersalmonspinachandavocadoterrine",
+                                                                      "key" : "3-tier salmon, spinach and avocado terrine",
+                                                                      "value" : [ "3-tier salmon, spinach and avocado terrine" ] ],
+                                                                    [ "id" : "Aberffrawcake",
+                                                                      "key" : "Aberffraw cake",
+                                                                      "value" : [ "Aberffraw cake" ] ],
+                                                                    [ "id" : "Adukiandorangecasserole-microwave",
+                                                                      "key" : "Aduki and orange casserole - microwave",
+                                                                      "value" : [ "Aduki and orange casserole - microwave" ] ],
+                                                                    [ "id" : "Aioli-garlicmayonnaise",
+                                                                      "key" : "Aioli - garlic mayonnaise",
+                                                                      "value" : ["Aioli - garlic mayonnaise" ] ],
+                                                                    [ "id" : "Alabamapeanutchicken",
+                                                                      "key" : "Alabama peanut chicken",
+                                                                      "value" : ["Alabama peanut chicken" ] ] ],
+                                                         "total_rows" : 2667],
+                                           statusCode: 200,
+                                           headers: [:])
+        })
+    }
+    
+    override public func tearDown() {
+        OHHTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+    
+    func testViewGeneratesCorrectRequestUsingStartAndEndKeys(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.descending = true
+        view.endKey = "endkey"
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.stale = .Ok
+        view.startKey = "startKey"
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET",view.httpMethod)
+        XCTAssertNil(view.httpRequestBody)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems = [ NSURLQueryItem(name: "descending", value: "true"),
+                                   NSURLQueryItem(name: "endkey", value: "\"endkey\""),
+                                   NSURLQueryItem(name: "include_docs", value: "true"),
+                                   NSURLQueryItem(name: "inclusive_end", value: "true"),
+                                   NSURLQueryItem(name: "limit", value: "4"),
+                                   NSURLQueryItem(name: "skip", value: "0"),
+                                   NSURLQueryItem(name: "stale", value: "ok"),
+                                   NSURLQueryItem(name: "startkey", value: "\"startKey\"") ]
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+    
+    func testViewGeneratesCorrectRequestUsingJsonStartAndEndKeys(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.descending = true
+        view.endKey = ["endkey","endkey2"]
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.stale = .Ok
+        view.startKey = ["startKey","startKey2"]
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET",view.httpMethod)
+        XCTAssertNil(view.httpRequestBody)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems:[NSURLQueryItem] = [ NSURLQueryItem(name: "descending", value: "true"),
+                                                    NSURLQueryItem(name: "endkey", value: "[\"endkey\",\"endkey2\"]"),
+                                                    NSURLQueryItem(name: "include_docs", value: "true"),
+                                                    NSURLQueryItem(name: "inclusive_end", value: "true"),
+                                                    NSURLQueryItem(name: "limit", value: "4"),
+                                                    NSURLQueryItem(name: "skip", value: "0"),
+                                                    NSURLQueryItem(name: "stale", value: "ok"),
+                                                    NSURLQueryItem(name: "startkey", value: "[\"startKey\",\"startKey2\"]") ]
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+    
+    func testViewGeneratesCorrectRequestUsingKey(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.descending = true
+        view.key = "testKey"
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.stale = .Ok
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET",view.httpMethod)
+        XCTAssertNil(view.httpRequestBody)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems:[NSURLQueryItem] = [ NSURLQueryItem(name: "descending", value: "true"),
+                                                    NSURLQueryItem(name: "key", value: "\"testKey\""),
+                                                    NSURLQueryItem(name: "include_docs", value: "true"),
+                                                    NSURLQueryItem(name: "inclusive_end", value: "true"),
+                                                    NSURLQueryItem(name: "limit", value: "4"),
+                                                    NSURLQueryItem(name: "skip", value: "0"),
+                                                    NSURLQueryItem(name: "stale", value: "ok") ]
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+    
+    func testViewGeneratesCorrectRequestUsingKeys(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.descending = true
+        view.keys = ["testkey",["testkey2","testkey3"]]
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.stale = .Ok
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("POST",view.httpMethod)
+        XCTAssertNotNil(view.httpRequestBody)
+        XCTAssertEqual("{\"keys\":[\"testkey\",[\"testkey2\",\"testkey3\"]]}",
+                       String(data:view.httpRequestBody!, encoding: NSUTF8StringEncoding))
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems:[NSURLQueryItem] = [ NSURLQueryItem(name: "descending", value: "true"),
+                                                    NSURLQueryItem(name: "include_docs", value: "true"),
+                                                    NSURLQueryItem(name: "inclusive_end", value: "true"),
+                                                    NSURLQueryItem(name: "limit", value: "4"),
+                                                    NSURLQueryItem(name: "skip", value: "0"),
+                                                    NSURLQueryItem(name: "stale", value: "ok") ]
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+    
+    func testViewGeneratesCorrectRequestForReduces() {
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.group = true
+        view.groupLevel = 3
+        view.reduce = true
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET",view.httpMethod)
+        XCTAssertNil(view.httpRequestBody)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems:[NSURLQueryItem] = [ NSURLQueryItem(name: "group", value: "true"),
+                                                    NSURLQueryItem(name: "group_level", value: "3"),
+                                                    NSURLQueryItem(name: "reduce", value: "true") ]
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+    
+    func testViewHandlesResponsesCorrectly(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        
+        var rowCount = 0
+        var first = true
+        let rowHandler = self.expectation(withDescription: "row handler")
+        let completionHandler = self.expectation(withDescription: "completion handler")
+        view.rowHandler = {(row) in
+            if(first){
+                rowHandler.fulfill()
+                first = false
+            }
+            rowCount += 1
+            XCTAssertNotNil(row)
+        }
+        
+        view.queryViewCompletionHandler = {(error) in
+            completionHandler.fulfill()
+            XCTAssertNil(error)
+        }
+        
+        self.client?[self.dbName!].add(operation: view)
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testOperationValidationMissingDDoc() {
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.viewName = "view1"
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testOperationValidationMissingViewname() {
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.designDoc = "ddoc"
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testOperationValidationReduceOptionsWithReduceFalseGroup(){
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        // reduce is true by default, so we need to explicitly set to false
+        view.reduce = false
+        view.group = true
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testOperationValidationReduceOptionsWithReduceFalseGroupLevel(){
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        // reduce is true by default, so we need to explicitly set to false
+        view.reduce = false
+        view.groupLevel = 3
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testOperationValidationReduceWithReduceGroup(){
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.group = true
+        view.reduce = true
+        XCTAssert(view.validate())
+    }
+    
+    func testOperationValidationReduceWithoutReduceGroup(){
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.group = true
+        XCTAssert(view.validate())
+    }
+    
+    func testOperationValidationReduceWithReduceGroupLevelWithoutGroup(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.groupLevel = 3
+        view.reduce = true
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testOperationValidationKeyAndKeys() {
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.key = "key"
+        view.keys = ["key1","key2"]
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testOperationValidationNoCompletionHandlers(){
+        let view = QueryViewOperation()
+        view.databaseName = "dbname"
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        XCTAssert(view.validate())
+    }
+    
+    func testOperationValidationMissingDBName(){
+        let view = QueryViewOperation()
+        view.viewName = "myView"
+        view.designDoc = "myddoc"
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testViewGeneratesCorrectRequestStaleDefault(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET",view.httpMethod)
+        XCTAssertNil(view.httpRequestBody)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems:[NSURLQueryItem] = []
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+    
+    func testViewGeneratesCorrectRequestStaleOk(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.databaseName = self.dbName
+        view.stale = .Ok
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET",view.httpMethod)
+        XCTAssertNil(view.httpRequestBody)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems:[NSURLQueryItem] = [ NSURLQueryItem(name: "stale", value: "ok") ]
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+    
+    func testViewGeneratesCorrectRequestStaleUpdateAfter(){
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.databaseName = self.dbName
+        view.stale = .UpdateAfter
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET",view.httpMethod)
+        XCTAssertNil(view.httpRequestBody)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
+        
+        let expectedQueryItems:[NSURLQueryItem] = [ NSURLQueryItem(name: "stale", value: "update_after") ]
+        
+        XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
+    }
+}

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -88,7 +88,7 @@ extension XCTestCase {
         create.waitUntilFinished()
     }
     
-    func deleteDatabase(databaseName:String, client:CouchDBClient) -> Void {
+    func deleteDatabase(databaseName: String, client: CouchDBClient) -> Void {
         let delete = DeleteDatabaseOperation()
         delete.databaseName = databaseName
         delete.deleteDatabaseCompletionHandler = {(statusCode, error) in
@@ -99,6 +99,7 @@ extension XCTestCase {
             }
             XCTAssertNil(error)
         }
+        client.add(operation: delete)
     }
 }
 

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -103,6 +103,31 @@ extension XCTestCase {
     }
 }
 
+extension Array where Element : NSURLQueryItem {
+    
+    /**
+     Checks if this array is equivalent to another array. For an array to be equivalent to another
+     they need to contain the same elements, however they do __not__ need to be in the same order.
+     
+     - parameter to: the `[NSURLQueryItem]` to compare to.
+     */
+    func isEquivalent(to:[NSURLQueryItem]) -> Bool {
+        var to = to
+        if(self.count != to.count){
+            return false
+        }
+        
+        for queryItem in self {
+            if let index = to.index(of: queryItem) {
+                to.remove(at: index)
+            } else {
+                return false
+            }
+        }
+        return to.count == 0
+    }
+}
+
 class TestSettings {
     
     private let settings: [String:AnyObject];
@@ -110,12 +135,12 @@ class TestSettings {
     
     private init() {
         let bundle = NSBundle(for: TestSettings.self)
-
+        
         let testSettingsPath = bundle.pathForResource("TestSettings", ofType: "plist")
         
         if let testSettingsPath = testSettingsPath,
-           let settingsDict = NSDictionary(contentsOfFile: testSettingsPath) as? [String:AnyObject] {
-           settings = settingsDict
+            let settingsDict = NSDictionary(contentsOfFile: testSettingsPath) as? [String:AnyObject] {
+            settings = settingsDict
         } else {
             settings = [:]
         }
@@ -129,5 +154,4 @@ class TestSettings {
             return instance!
         }
     }
-    
 }


### PR DESCRIPTION
*What*
Added support for querying a view

*How*
Added `QueryViewOperation` accepting properties for optional `queryViewCompletionHandler` and `rowHandler` for processing view results as well as properties for the request query options.

*Testing*
New test cases for querying a view and validation of operation.

reviewer @rhyshort 
reviewer @brynh