### PR TITLE
Add HTTP error to error lists

### DIFF
--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -61,6 +61,11 @@ enum Errors : ErrorProtocol {
      The JSON format wasn't what we expected.
      */
     case UnexpectedJSONFormat(statusCode:Int, response:String?)
+    
+    /**
+     A HTTP error status code (4xx or 5xx) was received (e.g. 400 Bad Request).
+     */
+    case HTTP(statusCode:Int, response:String?)
 };
 
 /**


### PR DESCRIPTION
This adds the HTTP error condition to the list of errors the library can throw, this is the first stage of #43 
