### PR TITLE
Use HTTP Error for HTTP Errors such as 4xx and 5xx

### DIFF
--- a/Source/CreateDatabaseOperation.swift
+++ b/Source/CreateDatabaseOperation.swift
@@ -78,7 +78,7 @@ public class CreateDatabaseOperation : CouchOperation {
             }
             
             self.createDatabaseCompletionHandler?(statusCode:statusCode,
-                                                 operationError: Errors.CreateDatabaseFailed(statusCode: statusCode, jsonResponse: response))
+                                                 operationError: Errors.HTTP(statusCode: statusCode, response: response))
         }
     }
 

--- a/Source/DeleteDatabaseOperation.swift
+++ b/Source/DeleteDatabaseOperation.swift
@@ -76,7 +76,7 @@ public class DeleteDatabaseOperation : CouchOperation {
                 response = nil
             }
             
-            self.deleteDatabaseCompletionHandler?(statusCode: statusCode, operationError:Errors.CreateDatabaseFailed(statusCode: statusCode, jsonResponse: response))
+            self.deleteDatabaseCompletionHandler?(statusCode: statusCode, operationError: Errors.HTTP(statusCode: statusCode, response: response))
         }
     }
     

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -103,10 +103,10 @@ public class GetDocumentOperation: CouchDatabaseOperation {
             }
         } else {
             guard let data = data else {
-                callCompletionHandler(error: Errors.GetDocumentFailed(statusCode: statusCode, jsonResponse: nil))
+                callCompletionHandler(error: Errors.HTTP(statusCode: statusCode, response: nil))
                 return
             }
-            callCompletionHandler(error:Errors.GetDocumentFailed(statusCode: statusCode, jsonResponse: String(data: data, encoding: NSUTF8StringEncoding )))
+            callCompletionHandler(error: Errors.HTTP(statusCode: statusCode, response: String(data: data, encoding: NSUTF8StringEncoding )))
         }
     }
 }

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -111,7 +111,7 @@ public class PutDocumentOperation: CouchDatabaseOperation {
                 putDocumentCompletionHandler?(docId: nil,
                                               revId: nil,
                                               statusCode: statusCode,
-                                              operationError: Errors.CreateUpdateDocumentFailed(statusCode: statusCode, jsonResponse: nil))
+                                              operationError: Errors.HTTP(statusCode: statusCode, response: nil))
                 return
             }
             
@@ -119,8 +119,8 @@ public class PutDocumentOperation: CouchDatabaseOperation {
             putDocumentCompletionHandler?(docId: nil,
                                           revId: nil,
                                           statusCode: statusCode,
-                                          operationError: Errors.CreateUpdateDocumentFailed(statusCode: statusCode,
-                                                                                          jsonResponse: String(data: data, encoding: NSUTF8StringEncoding)))
+                                          operationError: Errors.HTTP(statusCode: statusCode,
+                                                                                          response: String(data: data, encoding: NSUTF8StringEncoding)))
         }
     }
 }


### PR DESCRIPTION
## What 
Move away from using Error objects such as `.GetDocumentFailed` to using `.HTTP` error instead.

## Testing 
No new testing.

## Reviewers
reviewer @ricellis
