### PR TITLE
Remove unused errors

### DIFF
--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -22,41 +22,10 @@ import Foundation
  */
 enum Errors : ErrorProtocol {
     /**
-    Creating a database failed.
-    */
-    case CreateDatabaseFailed(statusCode:Int, jsonResponse:String?)
-    /**
-    Deleting a database failed.
-    */
-    case DeleteDatabaseFailed(statusCode:Int, jsonResponse:String?)
-    /**
     Validation of operation settings failed.
     */
     case ValidationFailed
-    /**
-    Deleting a Query index failed.
-    */
-    case DeleteQueryIndexFailed(statusCode:Int, jsonResponse:String?)
-    /**
-    Creating a Query index failed.
-    */
-    case CreateQueryIndexFailed(statusCode:Int, jsonResponse:String?)
-    /**
-    Getting a document failed.
-    */
-    case GetDocumentFailed(statusCode:Int, jsonResponse:String?)
-    /**
-    Creating or updating a document failed.
-    */
-    case CreateUpdateDocumentFailed(statusCode:Int, jsonResponse:String?)
-    /**
-    Deleting a document failed.
-    */
-    case DeleteDocumentFailed(statusCode:Int, jsonResponse:String?)
-    /**
-    Finding documents failed.
-    */
-    case FindDocumentsFailed(statusCode:Int, jsonResponse:String?)
+
     /**
      The JSON format wasn't what we expected.
      */

--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -32,7 +32,7 @@ enum Errors : ErrorProtocol {
     case UnexpectedJSONFormat(statusCode:Int, response:String?)
     
     /**
-     A HTTP error status code (4xx or 5xx) was received (e.g. 400 Bad Request).
+     An unexpected HTTP status code (e.g. 4xx or 5xx) was received.
      */
     case HTTP(statusCode:Int, response:String?)
 };

--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -32,11 +32,6 @@ enum Errors : ErrorProtocol {
     case UnexpectedJSONFormat(statusCode:Int, response:String?)
     
     /**
-     The query view operation failed.
-    */
-    case QueryViewFailed(statusCode: Int, response: String?)
-    
-    /**
      A HTTP error status code (4xx or 5xx) was received (e.g. 400 Bad Request).
      */
     case HTTP(statusCode:Int, response:String?)

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -353,7 +353,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
                 callCompletionHandler(error: error)
             }
         } else {
-            callCompletionHandler(error: Errors.QueryViewFailed(statusCode: statusCode, response: String(data, NSUTF8StringEncoding)))
+            callCompletionHandler(error: Errors.HTTP(statusCode: statusCode, response: String(data, NSUTF8StringEncoding)))
         }
     }
     


### PR DESCRIPTION
Part of #43 

Remove values from Errors enum which are no longer required, and move QueryViewOperation to using `.HTTP` error.

reviewer: @brynh