### PR TITLE
Change completion handler signatures

### DIFF
--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -128,7 +128,7 @@ public class CouchOperation : NSOperation, HTTPRequestOperation
         super.init()
     }
 
-    public func processResponse(data:NSData?, statusCode:Int, error:ErrorProtocol?){
+    public func processResponse(data:NSData?, httpInfo:HttpInfo?, error:ErrorProtocol?){
         
     }
     

--- a/Source/CreateDatabaseOperation.swift
+++ b/Source/CreateDatabaseOperation.swift
@@ -44,10 +44,11 @@ public class CreateDatabaseOperation : CouchOperation {
     /**
         A block to call when the operation completes
      
-     - parameter statusCode: the status code of the http response
-     - parameter operationError: The error that occured, or `nil` if processed succesfully.
+     - parameter response: The complete JSON response.
+     - parameter httpInfo: Information about the HTTP response.
+     - parameter error: The error that occured, or `nil` if processed succesfully.
      */
-    public var createDatabaseCompletionHandler : ((statusCode:Int?, operationError:ErrorProtocol?) -> Void)? = nil
+    public var createDatabaseCompletionHandler : ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
     
     
     public override func validate() -> Bool {
@@ -55,7 +56,7 @@ public class CreateDatabaseOperation : CouchOperation {
     }
     
     override public func callCompletionHandler(error: ErrorProtocol) {
-        self.createDatabaseCompletionHandler?(statusCode: nil, operationError: error)
+        self.createDatabaseCompletionHandler?(response:nil, httpInfo: nil, error: error)
     }
     
     public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
@@ -65,9 +66,11 @@ public class CreateDatabaseOperation : CouchOperation {
             return
         }
         
+        let httpInfo = HttpInfo(statusCode: statusCode, headers: [:])
+        
         if statusCode == 201 || statusCode ==  202 {
             /// success!
-            self.createDatabaseCompletionHandler?(statusCode: statusCode, operationError: nil)
+            self.createDatabaseCompletionHandler?(response:nil, httpInfo: httpInfo, error: nil)
         } else {
             
             let response: String?
@@ -77,8 +80,8 @@ public class CreateDatabaseOperation : CouchOperation {
                 response = nil
             }
             
-            self.createDatabaseCompletionHandler?(statusCode:statusCode,
-                                                 operationError: Errors.HTTP(statusCode: statusCode, response: response))
+            self.createDatabaseCompletionHandler?(response:nil, httpInfo: httpInfo,
+                                                 error: Errors.HTTP(statusCode: statusCode, response: response))
         }
     }
 

--- a/Source/Database.swift
+++ b/Source/Database.swift
@@ -67,8 +67,8 @@ public class Database  {
         
         
         var doc:[String:AnyObject]?
-        getDocument.getDocumentCompletionHandler = { (document, error ) in
-            doc = document
+        getDocument.getDocumentCompletionHandler = { (response, httpInfo, error ) in
+            doc = response
         };
         
         self.add(operation: getDocument)

--- a/Source/DeleteDatabaseOperation.swift
+++ b/Source/DeleteDatabaseOperation.swift
@@ -44,10 +44,11 @@ public class DeleteDatabaseOperation : CouchOperation {
     
     /**
         A block to call when the operation completes.
-     - parameter statusCode: The status code of the HTTP response.
-     - parameter operationError: The error that occurred if any.
+     - parameter response: The full JSON response.
+     - parameter httpInfo: Information about the HTTP response.
+     - parameter error: An Error that occured.
      */
-    public var deleteDatabaseCompletionHandler: ((statusCode:Int?, operationError:ErrorProtocol?) -> Void)? = nil
+    public var deleteDatabaseCompletionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
     
     
     public override func validate() -> Bool {
@@ -55,7 +56,7 @@ public class DeleteDatabaseOperation : CouchOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.deleteDatabaseCompletionHandler?(statusCode: nil, operationError: error)
+        self.deleteDatabaseCompletionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
     public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
@@ -65,9 +66,11 @@ public class DeleteDatabaseOperation : CouchOperation {
                 return
         }
         
+        let httpInfo = HttpInfo(statusCode: statusCode, headers: [:])
+        
         if statusCode == 200 || statusCode ==  202 { //Couch could return accepted instead of ok.
             /// success!
-            self.deleteDatabaseCompletionHandler?(statusCode: statusCode, operationError: nil)
+            self.deleteDatabaseCompletionHandler?(response:nil, httpInfo: httpInfo, error: nil)
         } else {
             let response:String?
             if let data = data {
@@ -76,7 +79,7 @@ public class DeleteDatabaseOperation : CouchOperation {
                 response = nil
             }
             
-            self.deleteDatabaseCompletionHandler?(statusCode: statusCode, operationError: Errors.HTTP(statusCode: statusCode, response: response))
+            self.deleteDatabaseCompletionHandler?(response:nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: statusCode, response: response))
         }
     }
     

--- a/Source/DeleteDocumentOperation.swift
+++ b/Source/DeleteDocumentOperation.swift
@@ -81,12 +81,36 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
         self.deleteDocumentCompletionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
-    public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
-        let httpInfo = HttpInfo(statusCode: statusCode, headers: [:])
-        if let error = error {
-            callCompletionHandler(error: error)
-        } else {
-            deleteDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: error);
+    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+        guard error == nil, let httpInfo = httpInfo
+            else {
+                self.callCompletionHandler(error: error!)
+                return;
+        }
+        
+        
+        do {
+            
+            if let data = data {
+                let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
+                
+                if httpInfo.statusCode / 100 == 2 {
+                    self.deleteDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: nil)
+                } else {
+                    self.deleteDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding: NSUTF8StringEncoding)))
+                }
+            } else {
+                self.deleteDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
+            }
+            
+        } catch {
+            let response:String?
+            if let data = data {
+                response = String(data:data, encoding: NSUTF8StringEncoding)
+            } else {
+                response = nil
+            }
+            self.deleteDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
     }
 }

--- a/Source/DeleteDocumentOperation.swift
+++ b/Source/DeleteDocumentOperation.swift
@@ -52,16 +52,14 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
     public var docId:String? = nil
     
     /**
-     * A block of code to call when the operation completes.
-     * This block will be called once per operation.
-     *
-     * statusCode: The status code returned from the request, will be nil if the operation
-     *                       did not make an http connection.
-     *
-     * error: An object representing the error that occured, will be nil when the operation
-     *                  successfully makes a HTTP request.
+      A block of code to call when the operation completes.
+      This block will be called once per operation.
+     
+      - parameter response: The full deseralised JSON response.
+      - parameter httpInfo: Information about the HTTP response.
+      - parameter error: An object representing the error that occured.
      */
-    public var deleteDocumentCompletionHandler : ((statusCode:Int?, error:ErrorProtocol?) ->())? = nil
+    public var deleteDocumentCompletionHandler : ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
     
     public override func validate() -> Bool {
         return super.validate() && revId != nil && docId != nil
@@ -80,14 +78,15 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.deleteDocumentCompletionHandler?(statusCode: nil,error: error)
+        self.deleteDocumentCompletionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
     public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
+        let httpInfo = HttpInfo(statusCode: statusCode, headers: [:])
         if let error = error {
             callCompletionHandler(error: error)
         } else {
-            deleteDocumentCompletionHandler?(statusCode: statusCode,error: error);
+            deleteDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: error);
         }
     }
 }

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -44,12 +44,12 @@ public class GetDocumentOperation: CouchDatabaseOperation {
     /**
       Completion block to run when the operation completes.
     
-      - parameter document: - The document read from the server
-    
-      - parameter operationError: - a pointer to an error object containing
+      - parameter response: - The full deseralised JSON response.
+      - parameter httpInfo: - Information about the HTTP response.
+      - parameter error: - a pointer to an error object containing
        information about an error executing the operation
     */
-    public var getDocumentCompletionHandler: ((document:[String:AnyObject]?, operationError:ErrorProtocol?) -> ())?
+    public var getDocumentCompletionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)?
 
     public override func validate() -> Bool {
         return super.validate() && docId != nil
@@ -80,7 +80,7 @@ public class GetDocumentOperation: CouchDatabaseOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.getDocumentCompletionHandler?(document: nil, operationError: error)
+        self.getDocumentCompletionHandler?(response:nil, httpInfo: nil ,error: error)
     }
     
     public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
@@ -88,6 +88,8 @@ public class GetDocumentOperation: CouchDatabaseOperation {
             callCompletionHandler(error:error)
             return
         }
+        
+        let httpInfo = HttpInfo(statusCode: statusCode, headers: [:])
         
         // Check status code is 200
         if statusCode == 200 {
@@ -97,7 +99,7 @@ public class GetDocumentOperation: CouchDatabaseOperation {
             
             do {
                 let json = try NSJSONSerialization.jsonObject(with:data, options: NSJSONReadingOptions())
-                getDocumentCompletionHandler?(document: json as? [String:AnyObject], operationError: nil)
+                getDocumentCompletionHandler?(response: json as? [String:AnyObject], httpInfo: httpInfo, error : nil)
             } catch {
                 callCompletionHandler(error:error)
             }

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -94,6 +94,7 @@ public class GetDocumentOperation: CouchDatabaseOperation {
             if let data = data {
                 let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
                 if httpInfo.statusCode == 200 {
+                    self.getDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: nil)
                 } else {
                     self.getDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding:NSUTF8StringEncoding)))
                 }

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -83,32 +83,33 @@ public class GetDocumentOperation: CouchDatabaseOperation {
         self.getDocumentCompletionHandler?(response:nil, httpInfo: nil ,error: error)
     }
     
-    public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
-        if let error = error {
-            callCompletionHandler(error:error)
+    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+        guard error == nil, let httpInfo = httpInfo
+        else {
+            callCompletionHandler(error:error!)
             return
         }
         
-        let httpInfo = HttpInfo(statusCode: statusCode, headers: [:])
-        
-        // Check status code is 200
-        if statusCode == 200 {
-            guard let data = data else {
-                return
+        do {
+            if let data = data {
+                let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
+                if httpInfo.statusCode == 200 {
+                } else {
+                    self.getDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding:NSUTF8StringEncoding)))
+                }
+                
+            } else {
+                self.getDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
+            }
+        } catch {
+            let response:String?
+            if let data = data {
+                response = String(data:data, encoding: NSUTF8StringEncoding)
+            } else {
+                response = nil
             }
             
-            do {
-                let json = try NSJSONSerialization.jsonObject(with:data, options: NSJSONReadingOptions())
-                getDocumentCompletionHandler?(response: json as? [String:AnyObject], httpInfo: httpInfo, error : nil)
-            } catch {
-                callCompletionHandler(error:error)
-            }
-        } else {
-            guard let data = data else {
-                callCompletionHandler(error: Errors.HTTP(statusCode: statusCode, response: nil))
-                return
-            }
-            callCompletionHandler(error: Errors.HTTP(statusCode: statusCode, response: String(data: data, encoding: NSUTF8StringEncoding )))
+            self.getDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
     }
 }

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -83,7 +83,7 @@ public class PutDocumentOperation: CouchDatabaseOperation {
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard error != nil, let httpInfo = httpInfo
+        guard error == nil, let httpInfo = httpInfo
         else {
             callCompletionHandler(error:error!)
             return

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -337,7 +337,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard  error != nil, let httpInfo = httpInfo
+        guard  error == nil, let httpInfo = httpInfo
         else {
             self.callCompletionHandler(error:error!)
             return

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -208,9 +208,11 @@ public class QueryViewOperation: CouchDatabaseOperation {
     /**
      Sets a completion handler to run when the operation completes.
      
+     - parameter response: - The full deseralised JSON response.
+     - parameter httpInfo: - Information about the HTTP response.
      - parameter error: - ErrorProtocol instance with information about an error executing the operation
      */
-    public var queryViewCompletionHandler: ((error: ErrorProtocol?) -> Void)?
+    public var queryViewCompletionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)?
     
     /**
      Sets a handler to run for each row retrieved by the view.
@@ -331,7 +333,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.queryViewCompletionHandler?(error: error)
+        self.queryViewCompletionHandler?(response:nil, httpInfo:nil, error: error)
     }
     
     public override func processResponse(data: NSData?, statusCode: Int, error: ErrorProtocol?) {
@@ -339,6 +341,8 @@ public class QueryViewOperation: CouchDatabaseOperation {
             self.callCompletionHandler(error:error)
             return
         }
+        
+        let httpInfo = HttpInfo(statusCode: statusCode, headers: [:])
         
         // Check status code is 200
         if statusCode == 200 {
@@ -348,7 +352,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
                 for row:[String:AnyObject] in rows {
                     self.rowHandler?(row: row)
                 }
-                self.queryViewCompletionHandler?(error: nil)
+                self.queryViewCompletionHandler?(response:nil, httpInfo:httpInfo, error: nil)
             } catch {
                 callCompletionHandler(error: error)
             }

--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -64,10 +64,10 @@ protocol HTTPRequestOperation {
       A function to process the response from a HTTP request.
      
      - parameter data: The data returned from the HTTP request or nil if there was an error.
-     - parameter statusCode: The statusCode of the HTTP response.
+     - parameter httpInfo: Information about the HTTP response.
      - parameter error: A type representing an error if one occurred or `nil`
      */
-    func processResponse(data:NSData?, statusCode:Int, error:ErrorProtocol?);
+    func processResponse(data:NSData?, httpInfo:HttpInfo?, error:ErrorProtocol?);
     
     var isCancelled: Bool { get }
     

--- a/Source/RequestExecutor.swift
+++ b/Source/RequestExecutor.swift
@@ -73,15 +73,15 @@ class OperationRequestExecutor {
             }
             
             
-            let statusCode: Int
+            let httpInfo: HttpInfo?
             
             if let response = response as? NSHTTPURLResponse {
-                statusCode = response.statusCode
+                httpInfo = HttpInfo(statusCode: response.statusCode, headers: response.allHeaderFields as! [String:String])
             } else {
-                statusCode = -1
+                httpInfo = nil
             }
             
-            self.operation.processResponse(data: data, statusCode: statusCode, error: error)
+            self.operation.processResponse(data: data, httpInfo: httpInfo, error: error)
             self.operation.completeOperation()
         
         })

--- a/Source/URLSession.swift
+++ b/Source/URLSession.swift
@@ -186,7 +186,7 @@ public class InterceptableSession {
     init(delegate:NSURLSessionDelegate?, requestInterceptors:Array<HTTPInterceptor>){
         interceptors = requestInterceptors
         
-        let config = NSURLSessionConfiguration.defaultSessionConfiguration()
+        let config = NSURLSessionConfiguration.default()
         config.httpAdditionalHeaders = ["User-Agent":InterceptableSession.userAgent()]
         session = NSURLSession(configuration: config,delegate:delegate, delegateQueue: nil)
     }

--- a/Tests/CreateDatabaseTests.swift
+++ b/Tests/CreateDatabaseTests.swift
@@ -45,11 +45,11 @@ class CreateDatabaseTests : XCTestCase {
         
         let create = CreateDatabaseOperation()
         create.databaseName = self.dbName
-        create.createDatabaseCompletionHandler = {( statusCode, error) in
+        create.createDatabaseCompletionHandler = {(response, httpInfo, error) in
             createExpectation.fulfill()
-            XCTAssertNotNil(statusCode)
-            if let statusCode = statusCode {
-                XCTAssertTrue(statusCode / 100 == 2)
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssertTrue(httpInfo.statusCode / 100 == 2)
             }
             XCTAssertNil(error)
         }

--- a/Tests/DeleteDocumentTests.swift
+++ b/Tests/DeleteDocumentTests.swift
@@ -41,21 +41,22 @@ class DeleteDocumentTests : XCTestCase {
         let db = client![self.dbName!]
         let expectation = self.expectation(withDescription: "Delete document")
         let delete = DeleteDocumentOperation()
-        delete.deleteDocumentCompletionHandler = {(statusCode, error) in
+        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
             expectation.fulfill()
-            XCTAssertNotNil(statusCode)
-            if let statusCode = statusCode {
-                XCTAssert(statusCode / 100 == 2)
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssert(httpInfo.statusCode / 100 == 2)
             }
             XCTAssertNil(error)
+            XCTAssertEqual(true,response?["ok"] as? Bool)
         }
         
         let create = PutDocumentOperation()
         create.docId = "testId"
         create.body = ["hello":"world"]
-        create.putDocumentCompletionHandler = {(docId,revId,statusCode,error) in
-            delete.revId = revId
-            delete.docId = docId
+        create.putDocumentCompletionHandler = {(response, httpInfo, error) in
+            delete.revId = response?["rev"] as? String
+            delete.docId = response?["id"] as? String
         }
         
         delete.addDependency(create)
@@ -73,9 +74,9 @@ class DeleteDocumentTests : XCTestCase {
         let expectation = self.expectation(withDescription: "Delete document")
         let delete = DeleteDocumentOperation()
         delete.docId = "testDocId"
-        delete.deleteDocumentCompletionHandler = {(statusCode, error) in
+        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
             expectation.fulfill()
-            XCTAssertNil(statusCode)
+            XCTAssertNil(httpInfo)
             XCTAssertNotNil(error)
         }
         
@@ -90,9 +91,9 @@ class DeleteDocumentTests : XCTestCase {
         let expectation = self.expectation(withDescription: "Delete document")
         let delete = DeleteDocumentOperation()
         delete.docId = "testDocId"
-        delete.deleteDocumentCompletionHandler = {(statusCode, error) in
+        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
             expectation.fulfill()
-            XCTAssertNil(statusCode)
+            XCTAssertNil(httpInfo)
             XCTAssertNotNil(error)
         }
         
@@ -105,10 +106,10 @@ class DeleteDocumentTests : XCTestCase {
         let db = client![self.dbName!]
         let expectation = self.expectation(withDescription:"Delete document")
         let delete = DeleteDocumentOperation()
-        delete.deleteDocumentCompletionHandler = {(statusCode, error) in
-            XCTAssertNotNil(statusCode)
-            if let statusCode = statusCode {
-                XCTAssert(statusCode / 100 == 2)
+        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssert(httpInfo.statusCode / 100 == 2)
             }
             XCTAssertNil(error)
         }
@@ -116,16 +117,16 @@ class DeleteDocumentTests : XCTestCase {
         let create = PutDocumentOperation()
         create.docId = "testId"
         create.body = ["hello":"world"]
-        create.putDocumentCompletionHandler = {(docId,revId,statusCode,error) in
-            delete.revId = revId
-            delete.docId = docId
+        create.putDocumentCompletionHandler = {(response, httpInfo, error) in
+            delete.revId = response?["rev"] as? String
+            delete.docId = response?["id"] as? String
         }
         
         let get = GetDocumentOperation()
         get.docId = "testId"
-        get.getDocumentCompletionHandler = {(document , error) in
+        get.getDocumentCompletionHandler = {(response, httpInfo, error) in
                         expectation.fulfill()
-                        XCTAssertNil(document)
+                        XCTAssertNil(response)
                         XCTAssertNotNil(error)
             }
         

--- a/Tests/GetDocumentTests.swift
+++ b/Tests/GetDocumentTests.swift
@@ -52,12 +52,13 @@ class GetDocumentTests : XCTestCase {
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
         
-        put.putDocumentCompletionHandler = { (docId, revId, statusCode, error) in
+        put.putDocumentCompletionHandler = { (response, httpInfo, error) in
             putDocumentExpectation.fulfill()
             XCTAssertNil(error)
-            XCTAssertNotNil(docId)
-            XCTAssertNotNil(revId)
-            XCTAssert(statusCode == 201 || statusCode == 202)
+            XCTAssertNotNil(response)
+            if let httpInfo = httpInfo {
+                XCTAssert(httpInfo.statusCode == 201 || httpInfo.statusCode == 202)
+            }
         }
         
         client.add(operation:put)
@@ -75,21 +76,24 @@ class GetDocumentTests : XCTestCase {
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
         put.databaseName = self.dbName
-        put.putDocumentCompletionHandler = { (docId,revId,statusCode, operationError) in
+        put.putDocumentCompletionHandler = { (response, httpInfo, operationError) in
             putDocumentExpectation.fulfill()
-            XCTAssertEqual(put.docId,docId);
-            XCTAssertNotNil(revId)
+            XCTAssertEqual(put.docId,response?["id"] as? String);
+            XCTAssertNotNil(response?["rev"])
             XCTAssertNil(operationError)
-            XCTAssertTrue(statusCode / 100 == 2)
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssertTrue(httpInfo.statusCode / 100 == 2)
+            }
             
             let get = GetDocumentOperation()
             get.docId = put.docId
             get.databaseName = self.dbName
             
-            get.getDocumentCompletionHandler = { (doc, error) in
+            get.getDocumentCompletionHandler = { (response, httpInfo, error) in
                 getDocumentExpectation.fulfill()
                 XCTAssertNil(error)
-                XCTAssertNotNil(doc)
+                XCTAssertNotNil(response)
             }
             
             self.client!.add(operation:get)
@@ -112,12 +116,15 @@ class GetDocumentTests : XCTestCase {
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
         put.databaseName = self.dbName
-        put.putDocumentCompletionHandler = { (docId,revId,statusCode, operationError) in
+        put.putDocumentCompletionHandler = { (response, httpInfo, error) in
             putDocumentExpectation.fulfill()
-            XCTAssertEqual(put.docId,docId);
-            XCTAssertNotNil(revId)
-            XCTAssertNil(operationError)
-            XCTAssertTrue(statusCode / 100 == 2)
+            XCTAssertEqual(put.docId,response?["id"] as? String);
+            XCTAssertNotNil(response?["rev"])
+            XCTAssertNil(error)
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+            XCTAssertTrue(httpInfo.statusCode / 100 == 2)
+            }
         };
         client?.add(operation:put)
         
@@ -138,12 +145,15 @@ class GetDocumentTests : XCTestCase {
         let put = PutDocumentOperation()
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
-        put.putDocumentCompletionHandler = { (docId,revId,statusCode, operationError) in
+        put.putDocumentCompletionHandler = { (response, httpInfo, operationError) in
             putDocumentExpectation.fulfill()
-            XCTAssertEqual(put.docId,docId);
-            XCTAssertNotNil(revId)
+            XCTAssertEqual(put.docId,response?["id"] as? String);
+            XCTAssertNotNil(response?["rev"])
             XCTAssertNil(operationError)
-            XCTAssertTrue(statusCode / 100 == 2)
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssertTrue(httpInfo.statusCode / 100 == 2)
+            }
             
 
         };
@@ -155,11 +165,16 @@ class GetDocumentTests : XCTestCase {
         get.docId = put.docId
         get.databaseName = self.dbName
         
-        get.getDocumentCompletionHandler = { (doc, error) in
+        get.getDocumentCompletionHandler = { (response, httpInfo, error) in
             getDocumentExpectation.fulfill()
             XCTAssertNil(error)
-            XCTAssertNotNil(doc)
+            XCTAssertNotNil(response)
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssertEqual(200, httpInfo.statusCode)
+            }
         }
+        
         
         client.add(operation:get)
         

--- a/Tests/PutDocumentTests.swift
+++ b/Tests/PutDocumentTests.swift
@@ -42,12 +42,15 @@ class PutDocumentTests : XCTestCase {
         let put = PutDocumentOperation()
         put.docId = "Doc1"
         put.body = ["hello":"world"]
-        put.putDocumentCompletionHandler = {(docId,revId,statusCode,error) in
+        put.putDocumentCompletionHandler = {(response,httpInfo,error) in
             putExpectation.fulfill()
-            XCTAssertNotNil(docId)
-            XCTAssertNotNil(revId)
-            XCTAssertEqual(2, statusCode / 100)
-            XCTAssertEqual("Doc1", docId)
+            XCTAssertEqual("Doc1", response?["id"] as? String)
+            XCTAssertNotNil(response?["rev"])
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssertEqual(2, httpInfo.statusCode / 100)
+            }
+
         }
         db.add(operation:put)
         

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -76,11 +76,10 @@ extension XCTestCase {
     func createDatabase(databaseName:String, client:CouchDBClient) -> Void {
         let create = CreateDatabaseOperation()
         create.databaseName = databaseName;
-        create.createDatabaseCompletionHandler = {(statusCode, error) in
-            if let statusCode = statusCode {
-                XCTAssert(statusCode / 100 == 2)
-            } else {
-                XCTAssertNotNil(statusCode)
+        create.createDatabaseCompletionHandler = {(response, httpInfo, error) in
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo  = httpInfo {
+                XCTAssert(httpInfo.statusCode / 100 == 2)
             }
             XCTAssertNil(error)
         }
@@ -91,11 +90,10 @@ extension XCTestCase {
     func deleteDatabase(databaseName: String, client: CouchDBClient) -> Void {
         let delete = DeleteDatabaseOperation()
         delete.databaseName = databaseName
-        delete.deleteDatabaseCompletionHandler = {(statusCode, error) in
-            if let statusCode = statusCode {
-                XCTAssert(statusCode / 100 == 2)
-            } else {
-                XCTAssertNotNil(statusCode)
+        delete.deleteDatabaseCompletionHandler = {(response, httpInfo, error) in
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssert(httpInfo.statusCode / 100 == 2)
             }
             XCTAssertNil(error)
         }


### PR DESCRIPTION
## What
Change the completion handler signatures to be of type `((response:[String:AnyObject]?, httpInfo:HttpInfo?,error:ErrorProtocol?) -> Void)?`

## How
- Change completion handler signature across all operations.
- Changes the HTTPOperation protocol to pass in `HttpInfo` instead of `statusCode`

## Testing
No new testing, all tests have been updated to reflect the completion handler changes however.

## Reviewers
reviewer @ricellis 
## Issues
Part of #43 
