### PR TITLE
Make Completion handlers and processResponse functions common

### DIFF
--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -127,7 +127,7 @@ public class CouchOperation : NSOperation, HTTPRequestOperation
      
      - parameter response: - The full deseralised JSON response.
      - parameter httpInfo: - Information about the HTTP response.
-     - parameter error: - ErrorProtocol instance with information about an error executing the operation
+     - parameter error: - ErrorProtocol instance with information about an error executing the operation.
     */
     public var completionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
     
@@ -137,9 +137,37 @@ public class CouchOperation : NSOperation, HTTPRequestOperation
         super.init()
     }
 
-    public func processResponse(data:NSData?, httpInfo:HttpInfo?, error:ErrorProtocol?){
+    public func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+        guard error == nil, let httpInfo = httpInfo
+            else  {
+                self.callCompletionHandler(error: error!)
+                return
+        }
+        
+        do {
+            if let data = data {
+                let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
+                
+                if httpInfo.statusCode / 100 == 2 {
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
+                } else {
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data: data, encoding: NSUTF8StringEncoding)))
+                }
+            } else {
+                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
+            }
+        } catch {
+            let response:String?
+            if let data = data {
+                response = String(data: data, encoding: NSUTF8StringEncoding)
+            } else {
+                response = nil
+            }
+            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
+        }
         
     }
+
     
     /**
      Calls the completion handler for the operation with the specified error.

--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -122,6 +122,15 @@ public class CouchOperation : NSOperation, HTTPRequestOperation
         }
     }
     
+    /**
+     Sets a completion handler to run when the operation completes.
+     
+     - parameter response: - The full deseralised JSON response.
+     - parameter httpInfo: - Information about the HTTP response.
+     - parameter error: - ErrorProtocol instance with information about an error executing the operation
+    */
+    public var completionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
+    
     private var executor:OperationRequestExecutor? = nil
     
     public override init() {

--- a/Source/CreateDatabaseOperation.swift
+++ b/Source/CreateDatabaseOperation.swift
@@ -41,22 +41,13 @@ public class CreateDatabaseOperation : CouchOperation {
         }
     }
     
-    /**
-        A block to call when the operation completes
-     
-     - parameter response: The complete JSON response.
-     - parameter httpInfo: Information about the HTTP response.
-     - parameter error: The error that occured, or `nil` if processed succesfully.
-     */
-    public var createDatabaseCompletionHandler : ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
-    
     
     public override func validate() -> Bool {
         return super.validate() && self.databaseName != nil // should work iirc
     }
     
     override public func callCompletionHandler(error: ErrorProtocol) {
-        self.createDatabaseCompletionHandler?(response:nil, httpInfo: nil, error: error)
+        self.completionHandler?(response:nil, httpInfo: nil, error: error)
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
@@ -71,12 +62,12 @@ public class CreateDatabaseOperation : CouchOperation {
                 let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
                 
                 if httpInfo.statusCode == 201 || httpInfo.statusCode ==  202 {
-                    self.createDatabaseCompletionHandler?(response: json, httpInfo: httpInfo, error: nil)
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
                 } else {
-                    self.createDatabaseCompletionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data: data, encoding: NSUTF8StringEncoding)))
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data: data, encoding: NSUTF8StringEncoding)))
                 }
             } else {
-                self.createDatabaseCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
+                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
             }
         } catch {
             let response:String?
@@ -85,7 +76,7 @@ public class CreateDatabaseOperation : CouchOperation {
             } else {
                 response = nil
             }
-            self.createDatabaseCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
+            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
 
     }

--- a/Source/CreateDatabaseOperation.swift
+++ b/Source/CreateDatabaseOperation.swift
@@ -50,35 +50,4 @@ public class CreateDatabaseOperation : CouchOperation {
         self.completionHandler?(response:nil, httpInfo: nil, error: error)
     }
     
-    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard error == nil, let httpInfo = httpInfo
-        else  {
-            self.callCompletionHandler(error: error!)
-            return
-        }
-        
-        do {
-            if let data = data {
-                let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
-                
-                if httpInfo.statusCode == 201 || httpInfo.statusCode ==  202 {
-                    self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
-                } else {
-                    self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data: data, encoding: NSUTF8StringEncoding)))
-                }
-            } else {
-                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
-            }
-        } catch {
-            let response:String?
-            if let data = data {
-               response = String(data: data, encoding: NSUTF8StringEncoding)
-            } else {
-                response = nil
-            }
-            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
-        }
-
-    }
-
 }

--- a/Source/Database.swift
+++ b/Source/Database.swift
@@ -67,7 +67,7 @@ public class Database  {
         
         
         var doc:[String:AnyObject]?
-        getDocument.getDocumentCompletionHandler = { (response, httpInfo, error ) in
+        getDocument.completionHandler = { (response, httpInfo, error ) in
             doc = response
         };
         

--- a/Source/DeleteDatabaseOperation.swift
+++ b/Source/DeleteDatabaseOperation.swift
@@ -50,40 +50,4 @@ public class DeleteDatabaseOperation : CouchOperation {
         self.completionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
-    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard error == nil, let httpInfo = httpInfo
-            else  {
-                self.callCompletionHandler(error: error!)
-                return
-        }
-        
-        do {
-            if let data = data {
-                let json = try NSJSONSerialization.jsonObject(with: data) as! [String: AnyObject]
-                
-                if httpInfo.statusCode == 200 || httpInfo.statusCode ==  202 { //Couch could return accepted instead of ok.
-                    /// success!
-                    self.completionHandler?(response:json, httpInfo: httpInfo, error: nil)
-                } else {
-                    let response = String(data: data, encoding: NSUTF8StringEncoding)
-                    self.completionHandler?(response:json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: response))
-                }
-                
-            } else {
-                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: nil))
-            }
-        } catch {
-            let response:String?
-            if let data = data {
-                response = String(data:data, encoding: NSUTF8StringEncoding)
-            } else {
-                response = nil
-            }
-            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
-        }
-        
-        
-
-    }
-    
 }

--- a/Source/DeleteDatabaseOperation.swift
+++ b/Source/DeleteDatabaseOperation.swift
@@ -42,21 +42,12 @@ public class DeleteDatabaseOperation : CouchOperation {
         }
     }
     
-    /**
-        A block to call when the operation completes.
-     - parameter response: The full JSON response.
-     - parameter httpInfo: Information about the HTTP response.
-     - parameter error: An Error that occured.
-     */
-    public var deleteDatabaseCompletionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
-    
-    
     public override func validate() -> Bool {
         return super.validate() && self.databaseName != nil // should work iirc
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.deleteDatabaseCompletionHandler?(response: nil, httpInfo: nil, error: error)
+        self.completionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
@@ -72,14 +63,14 @@ public class DeleteDatabaseOperation : CouchOperation {
                 
                 if httpInfo.statusCode == 200 || httpInfo.statusCode ==  202 { //Couch could return accepted instead of ok.
                     /// success!
-                    self.deleteDatabaseCompletionHandler?(response:json, httpInfo: httpInfo, error: nil)
+                    self.completionHandler?(response:json, httpInfo: httpInfo, error: nil)
                 } else {
                     let response = String(data: data, encoding: NSUTF8StringEncoding)
-                    self.deleteDatabaseCompletionHandler?(response:json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: response))
+                    self.completionHandler?(response:json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: response))
                 }
                 
             } else {
-                self.deleteDatabaseCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: nil))
+                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: nil))
             }
         } catch {
             let response:String?
@@ -88,7 +79,7 @@ public class DeleteDatabaseOperation : CouchOperation {
             } else {
                 response = nil
             }
-            self.deleteDatabaseCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
+            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
         
         

--- a/Source/DeleteDocumentOperation.swift
+++ b/Source/DeleteDocumentOperation.swift
@@ -51,16 +51,6 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
      */
     public var docId:String? = nil
     
-    /**
-      A block of code to call when the operation completes.
-      This block will be called once per operation.
-     
-      - parameter response: The full deseralised JSON response.
-      - parameter httpInfo: Information about the HTTP response.
-      - parameter error: An object representing the error that occured.
-     */
-    public var deleteDocumentCompletionHandler : ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
-    
     public override func validate() -> Bool {
         return super.validate() && revId != nil && docId != nil
     }
@@ -78,7 +68,7 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.deleteDocumentCompletionHandler?(response: nil, httpInfo: nil, error: error)
+        self.completionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
@@ -95,12 +85,12 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
                 let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
                 
                 if httpInfo.statusCode / 100 == 2 {
-                    self.deleteDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: nil)
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
                 } else {
-                    self.deleteDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding: NSUTF8StringEncoding)))
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding: NSUTF8StringEncoding)))
                 }
             } else {
-                self.deleteDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
+                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
             }
             
         } catch {
@@ -110,7 +100,7 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
             } else {
                 response = nil
             }
-            self.deleteDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
+            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
     }
 }

--- a/Source/DeleteDocumentOperation.swift
+++ b/Source/DeleteDocumentOperation.swift
@@ -70,37 +70,5 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
     public override func callCompletionHandler(error: ErrorProtocol) {
         self.completionHandler?(response: nil, httpInfo: nil, error: error)
     }
-    
-    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard error == nil, let httpInfo = httpInfo
-            else {
-                self.callCompletionHandler(error: error!)
-                return;
-        }
-        
-        
-        do {
-            
-            if let data = data {
-                let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
-                
-                if httpInfo.statusCode / 100 == 2 {
-                    self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
-                } else {
-                    self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding: NSUTF8StringEncoding)))
-                }
-            } else {
-                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
-            }
-            
-        } catch {
-            let response:String?
-            if let data = data {
-                response = String(data:data, encoding: NSUTF8StringEncoding)
-            } else {
-                response = nil
-            }
-            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
-        }
-    }
+
 }

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -73,34 +73,4 @@ public class GetDocumentOperation: CouchDatabaseOperation {
         self.completionHandler?(response:nil, httpInfo: nil ,error: error)
     }
     
-    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard error == nil, let httpInfo = httpInfo
-        else {
-            callCompletionHandler(error:error!)
-            return
-        }
-        
-        do {
-            if let data = data {
-                let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
-                if httpInfo.statusCode == 200 {
-                    self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
-                } else {
-                    self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding:NSUTF8StringEncoding)))
-                }
-                
-            } else {
-                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
-            }
-        } catch {
-            let response:String?
-            if let data = data {
-                response = String(data:data, encoding: NSUTF8StringEncoding)
-            } else {
-                response = nil
-            }
-            
-            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
-        }
-    }
 }

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -40,16 +40,6 @@ public class GetDocumentOperation: CouchDatabaseOperation {
       Must be set before a call can be successfully made.
     */
     public var docId: String? = nil
-    
-    /**
-      Completion block to run when the operation completes.
-    
-      - parameter response: - The full deseralised JSON response.
-      - parameter httpInfo: - Information about the HTTP response.
-      - parameter error: - a pointer to an error object containing
-       information about an error executing the operation
-    */
-    public var getDocumentCompletionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)?
 
     public override func validate() -> Bool {
         return super.validate() && docId != nil
@@ -80,7 +70,7 @@ public class GetDocumentOperation: CouchDatabaseOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.getDocumentCompletionHandler?(response:nil, httpInfo: nil ,error: error)
+        self.completionHandler?(response:nil, httpInfo: nil ,error: error)
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
@@ -94,13 +84,13 @@ public class GetDocumentOperation: CouchDatabaseOperation {
             if let data = data {
                 let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
                 if httpInfo.statusCode == 200 {
-                    self.getDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: nil)
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
                 } else {
-                    self.getDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding:NSUTF8StringEncoding)))
+                    self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding:NSUTF8StringEncoding)))
                 }
                 
             } else {
-                self.getDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
+                self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
             }
         } catch {
             let response:String?
@@ -110,7 +100,7 @@ public class GetDocumentOperation: CouchDatabaseOperation {
                 response = nil
             }
             
-            self.getDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
+            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
     }
 }

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -32,16 +32,6 @@ public class PutDocumentOperation: CouchDatabaseOperation {
     
     /** Body of document. Must be serialisable with NSJSONSerialization */
     public var body: [String:AnyObject]? = nil
-
-    /**
-    Completion block to run when the operation completes.
-    
-     - parameter response: - The full deseralised JSON response.
-     - parameter httpInfo: - Information about the HTTP response.
-     - parameter error: - a pointer to an error object containing
-     information about an error executing the operation
-    */
-    var putDocumentCompletionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)? = nil
     
     public override func validate() -> Bool {
         return super.validate() && docId != nil && body != nil && NSJSONSerialization.isValidJSONObject(body!)
@@ -79,7 +69,7 @@ public class PutDocumentOperation: CouchDatabaseOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        putDocumentCompletionHandler?(response: nil, httpInfo: nil, error: error)
+        completionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
@@ -94,13 +84,13 @@ public class PutDocumentOperation: CouchDatabaseOperation {
                 let json = try NSJSONSerialization.jsonObject(with: data) as! [String: AnyObject]
                 // Check status code
                 if httpInfo.statusCode == 201 || httpInfo.statusCode == 202 {
-                      putDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: nil)
+                      completionHandler?(response: json, httpInfo: httpInfo, error: nil)
                 } else {
-                    putDocumentCompletionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding: NSUTF8StringEncoding)))
+                    completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding: NSUTF8StringEncoding)))
                 }
                 
             } else {
-              self.putDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
+              self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
             }
         } catch {
             let response:String?
@@ -109,7 +99,7 @@ public class PutDocumentOperation: CouchDatabaseOperation {
             } else {
                 response = nil
             }
-            self.putDocumentCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
+            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
 
     }

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -71,36 +71,5 @@ public class PutDocumentOperation: CouchDatabaseOperation {
     public override func callCompletionHandler(error: ErrorProtocol) {
         completionHandler?(response: nil, httpInfo: nil, error: error)
     }
-    
-    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard error == nil, let httpInfo = httpInfo
-        else {
-            callCompletionHandler(error:error!)
-            return
-        }
-        
-        do {
-            if let data = data {
-                let json = try NSJSONSerialization.jsonObject(with: data) as! [String: AnyObject]
-                // Check status code
-                if httpInfo.statusCode == 201 || httpInfo.statusCode == 202 {
-                      completionHandler?(response: json, httpInfo: httpInfo, error: nil)
-                } else {
-                    completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data:data, encoding: NSUTF8StringEncoding)))
-                }
-                
-            } else {
-              self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: nil))
-            }
-        } catch {
-            let response:String?
-            if let data = data {
-                response = String(data:data, encoding: NSUTF8StringEncoding)
-            } else {
-                response = nil
-            }
-            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
-        }
 
-    }
 }

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -206,15 +206,6 @@ public class QueryViewOperation: CouchDatabaseOperation {
     public var stale: Stale? = nil
     
     /**
-     Sets a completion handler to run when the operation completes.
-     
-     - parameter response: - The full deseralised JSON response.
-     - parameter httpInfo: - Information about the HTTP response.
-     - parameter error: - ErrorProtocol instance with information about an error executing the operation
-     */
-    public var queryViewCompletionHandler: ((response:[String:AnyObject]?, httpInfo: HttpInfo?, error:ErrorProtocol?)-> Void)?
-    
-    /**
      Sets a handler to run for each row retrieved by the view.
      
      - parameter row: dictionary of the JSON data from the view row
@@ -333,7 +324,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
     }
     
     public override func callCompletionHandler(error: ErrorProtocol) {
-        self.queryViewCompletionHandler?(response:nil, httpInfo:nil, error: error)
+        self.completionHandler?(response:nil, httpInfo:nil, error: error)
     }
     
     public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
@@ -351,7 +342,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
                     for row:[String:AnyObject] in rows {
                         self.rowHandler?(row: row)
                     }
-                    self.queryViewCompletionHandler?(response:json, httpInfo:httpInfo, error: nil)
+                    self.completionHandler?(response:json, httpInfo:httpInfo, error: nil)
                 } else {
                     callCompletionHandler(error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data, NSUTF8StringEncoding)))
                 }
@@ -365,7 +356,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
             } else {
                 response = nil
             }
-            self.queryViewCompletionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
+            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
 
     }

--- a/Tests/CreateDatabaseTests.swift
+++ b/Tests/CreateDatabaseTests.swift
@@ -45,7 +45,7 @@ class CreateDatabaseTests : XCTestCase {
         
         let create = CreateDatabaseOperation()
         create.databaseName = self.dbName
-        create.createDatabaseCompletionHandler = {(response, httpInfo, error) in
+        create.completionHandler = {(response, httpInfo, error) in
             createExpectation.fulfill()
             XCTAssertNotNil(httpInfo)
             if let httpInfo = httpInfo {

--- a/Tests/DeleteDocumentTests.swift
+++ b/Tests/DeleteDocumentTests.swift
@@ -41,7 +41,7 @@ class DeleteDocumentTests : XCTestCase {
         let db = client![self.dbName!]
         let expectation = self.expectation(withDescription: "Delete document")
         let delete = DeleteDocumentOperation()
-        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
+        delete.completionHandler = {(response, httpInfo, error) in
             expectation.fulfill()
             XCTAssertNotNil(httpInfo)
             if let httpInfo = httpInfo {
@@ -54,7 +54,7 @@ class DeleteDocumentTests : XCTestCase {
         let create = PutDocumentOperation()
         create.docId = "testId"
         create.body = ["hello":"world"]
-        create.putDocumentCompletionHandler = {(response, httpInfo, error) in
+        create.completionHandler = {(response, httpInfo, error) in
             delete.revId = response?["rev"] as? String
             delete.docId = response?["id"] as? String
         }
@@ -74,7 +74,7 @@ class DeleteDocumentTests : XCTestCase {
         let expectation = self.expectation(withDescription: "Delete document")
         let delete = DeleteDocumentOperation()
         delete.docId = "testDocId"
-        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
+        delete.completionHandler = {(response, httpInfo, error) in
             expectation.fulfill()
             XCTAssertNil(httpInfo)
             XCTAssertNotNil(error)
@@ -91,7 +91,7 @@ class DeleteDocumentTests : XCTestCase {
         let expectation = self.expectation(withDescription: "Delete document")
         let delete = DeleteDocumentOperation()
         delete.docId = "testDocId"
-        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
+        delete.completionHandler = {(response, httpInfo, error) in
             expectation.fulfill()
             XCTAssertNil(httpInfo)
             XCTAssertNotNil(error)
@@ -106,7 +106,7 @@ class DeleteDocumentTests : XCTestCase {
         let db = client![self.dbName!]
         let expectation = self.expectation(withDescription:"Delete document")
         let delete = DeleteDocumentOperation()
-        delete.deleteDocumentCompletionHandler = {(response, httpInfo, error) in
+        delete.completionHandler = {(response, httpInfo, error) in
             XCTAssertNotNil(httpInfo)
             if let httpInfo = httpInfo {
                 XCTAssert(httpInfo.statusCode / 100 == 2)
@@ -117,14 +117,14 @@ class DeleteDocumentTests : XCTestCase {
         let create = PutDocumentOperation()
         create.docId = "testId"
         create.body = ["hello":"world"]
-        create.putDocumentCompletionHandler = {(response, httpInfo, error) in
+        create.completionHandler = {(response, httpInfo, error) in
             delete.revId = response?["rev"] as? String
             delete.docId = response?["id"] as? String
         }
         
         let get = GetDocumentOperation()
         get.docId = "testId"
-        get.getDocumentCompletionHandler = {(response, httpInfo, error) in
+        get.completionHandler = {(response, httpInfo, error) in
                         expectation.fulfill()
                         XCTAssertNil(response)
                         XCTAssertNotNil(error)

--- a/Tests/GetDocumentTests.swift
+++ b/Tests/GetDocumentTests.swift
@@ -52,7 +52,7 @@ class GetDocumentTests : XCTestCase {
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
         
-        put.putDocumentCompletionHandler = { (response, httpInfo, error) in
+        put.completionHandler = { (response, httpInfo, error) in
             putDocumentExpectation.fulfill()
             XCTAssertNil(error)
             XCTAssertNotNil(response)
@@ -76,7 +76,7 @@ class GetDocumentTests : XCTestCase {
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
         put.databaseName = self.dbName
-        put.putDocumentCompletionHandler = { (response, httpInfo, operationError) in
+        put.completionHandler = { (response, httpInfo, operationError) in
             putDocumentExpectation.fulfill()
             XCTAssertEqual(put.docId,response?["id"] as? String);
             XCTAssertNotNil(response?["rev"])
@@ -90,7 +90,7 @@ class GetDocumentTests : XCTestCase {
             get.docId = put.docId
             get.databaseName = self.dbName
             
-            get.getDocumentCompletionHandler = { (response, httpInfo, error) in
+            get.completionHandler = { (response, httpInfo, error) in
                 getDocumentExpectation.fulfill()
                 XCTAssertNil(error)
                 XCTAssertNotNil(response)
@@ -116,7 +116,7 @@ class GetDocumentTests : XCTestCase {
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
         put.databaseName = self.dbName
-        put.putDocumentCompletionHandler = { (response, httpInfo, error) in
+        put.completionHandler = { (response, httpInfo, error) in
             putDocumentExpectation.fulfill()
             XCTAssertEqual(put.docId,response?["id"] as? String);
             XCTAssertNotNil(response?["rev"])
@@ -145,7 +145,7 @@ class GetDocumentTests : XCTestCase {
         let put = PutDocumentOperation()
         put.body = data[0]
         put.docId = NSUUID().uuidString.lowercased()
-        put.putDocumentCompletionHandler = { (response, httpInfo, operationError) in
+        put.completionHandler = { (response, httpInfo, operationError) in
             putDocumentExpectation.fulfill()
             XCTAssertEqual(put.docId,response?["id"] as? String);
             XCTAssertNotNil(response?["rev"])
@@ -165,7 +165,7 @@ class GetDocumentTests : XCTestCase {
         get.docId = put.docId
         get.databaseName = self.dbName
         
-        get.getDocumentCompletionHandler = { (response, httpInfo, error) in
+        get.completionHandler = { (response, httpInfo, error) in
             getDocumentExpectation.fulfill()
             XCTAssertNil(error)
             XCTAssertNotNil(response)

--- a/Tests/PutDocumentTests.swift
+++ b/Tests/PutDocumentTests.swift
@@ -42,7 +42,7 @@ class PutDocumentTests : XCTestCase {
         let put = PutDocumentOperation()
         put.docId = "Doc1"
         put.body = ["hello":"world"]
-        put.putDocumentCompletionHandler = {(response,httpInfo,error) in
+        put.completionHandler = {(response,httpInfo,error) in
             putExpectation.fulfill()
             XCTAssertEqual("Doc1", response?["id"] as? String)
             XCTAssertNotNil(response?["rev"])

--- a/Tests/QueryViewTests.swift
+++ b/Tests/QueryViewTests.swift
@@ -219,7 +219,7 @@ public class QueryViewTests : XCTestCase {
             XCTAssertNotNil(row)
         }
         
-        view.queryViewCompletionHandler = {(error) in
+        view.completionHandler = {(error) in
             completionHandler.fulfill()
             XCTAssertNil(error)
         }

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -76,7 +76,7 @@ extension XCTestCase {
     func createDatabase(databaseName:String, client:CouchDBClient) -> Void {
         let create = CreateDatabaseOperation()
         create.databaseName = databaseName;
-        create.createDatabaseCompletionHandler = {(response, httpInfo, error) in
+        create.completionHandler = {(response, httpInfo, error) in
             XCTAssertNotNil(httpInfo)
             if let httpInfo  = httpInfo {
                 XCTAssert(httpInfo.statusCode / 100 == 2)
@@ -90,7 +90,7 @@ extension XCTestCase {
     func deleteDatabase(databaseName: String, client: CouchDBClient) -> Void {
         let delete = DeleteDatabaseOperation()
         delete.databaseName = databaseName
-        delete.deleteDatabaseCompletionHandler = {(response, httpInfo, error) in
+        delete.completionHandler = {(response, httpInfo, error) in
             XCTAssertNotNil(httpInfo)
             if let httpInfo = httpInfo {
                 XCTAssert(httpInfo.statusCode / 100 == 2)


### PR DESCRIPTION
## What
Make completionHandlers and processResponses functions common.

## How
- Move `completionHandlers` properties to a single `completionHandler` property on `CouchOperation`
- Make the subclasses `processResponse` function common, and provide implementation in `CouchOperation`, this does not apply to view operations yet since that will require and additional hook to provide row handling.

## Reviewers
reveiwer @brynh 
## Issues
Part of #43 