### PR TITLE
Provide hook for executing additional handlers

### DIFF
--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -147,8 +147,8 @@ public class CouchOperation : NSOperation, HTTPRequestOperation
         do {
             if let data = data {
                 let json = try NSJSONSerialization.jsonObject(with: data) as! [String:AnyObject]
-                
                 if httpInfo.statusCode / 100 == 2 {
+                    self.processResponse(json: json)
                     self.completionHandler?(response: json, httpInfo: httpInfo, error: nil)
                 } else {
                     self.completionHandler?(response: json, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data: data, encoding: NSUTF8StringEncoding)))
@@ -166,6 +166,19 @@ public class CouchOperation : NSOperation, HTTPRequestOperation
             self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
         }
         
+    }
+    
+    /**
+     This method is called from the
+     `processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?)` method,
+     it will contain the deserialized json response in the event the request returned with a
+     2xx status code. 
+     
+     - Note: This should be overridden to trigger other handlers such as a handler for each row of
+     a returned view.
+     */
+    public func processResponse(json: [String:AnyObject]) {
+        return
     }
 
     

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -327,38 +327,11 @@ public class QueryViewOperation: CouchDatabaseOperation {
         self.completionHandler?(response:nil, httpInfo:nil, error: error)
     }
     
-    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
-        guard  error == nil, let httpInfo = httpInfo
-        else {
-            self.callCompletionHandler(error:error!)
-            return
+    public override func processResponse(json: [String : AnyObject]) {
+        let rows = json["rows"] as! [[String:AnyObject]]
+        for row:[String:AnyObject] in rows {
+            self.rowHandler?(row: row)
         }
-        
-        do {
-            if let data = data {
-                let json = try NSJSONSerialization.jsonObject(with: data) as! [String: AnyObject]
-                if httpInfo.statusCode == 200 {  // Check status code is 200
-                    let rows = json["rows"] as! [[String:AnyObject]]
-                    for row:[String:AnyObject] in rows {
-                        self.rowHandler?(row: row)
-                    }
-                    self.completionHandler?(response:json, httpInfo:httpInfo, error: nil)
-                } else {
-                    callCompletionHandler(error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data, NSUTF8StringEncoding)))
-                }
-            }
-            
-            
-        } catch {
-            let response: String?
-            if let data = data {
-                response = String(data:data, encoding: NSUTF8StringEncoding)
-            } else {
-                response = nil
-            }
-            self.completionHandler?(response: nil, httpInfo: httpInfo, error: Errors.UnexpectedJSONFormat(statusCode: httpInfo.statusCode, response: response))
-        }
-
     }
     
     func convertJson(key: AnyObject) -> String {


### PR DESCRIPTION
## What
Provide a hook into `CouchOperation` to make it possible to call additional completion handlers without reimplementing response processing logic.

## How
Added a new hook into CouchOperation processResponse(json: [String:AnyObkect]) to enable
running of additional completion handlers.

## Reviewers

## Issues
Part of #43 