### PR TITLE
Don't crash if URL generation fails.

### DIFF
--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -78,6 +78,10 @@ protocol HTTPRequestOperation {
  */
 class OperationRequestBuilder {
     
+    enum Error : ErrorProtocol {
+        case URLGenerationFailed
+    }
+    
     /**
      The operation this builder will turn into a HTTP object.
     */
@@ -95,11 +99,10 @@ class OperationRequestBuilder {
     /**
         Builds the NSURLRequest from the operation in the property `operation`
      */
-    func buildRequest() -> NSURLRequest {
+    func buildRequest() throws -> NSURLRequest {
         guard let components = NSURLComponents(url: operation.rootURL, resolvingAgainstBaseURL: false)
         else {
-            //crash for now
-            abort()
+            throw Error.URLGenerationFailed
         }
         components.path = operation.httpPath
         var queryItems : [NSURLQueryItem] = []
@@ -113,9 +116,9 @@ class OperationRequestBuilder {
         
         guard let url = components.url
         else {
-            // crash for now
-            abort()
+            throw Error.URLGenerationFailed
         }
+        
         let request = NSMutableURLRequest(url: url)
         request.cachePolicy = .useProtocolCachePolicy
         request.timeoutInterval = 10.0


### PR DESCRIPTION
## What
Don't crash if RequestBuilder fails to generate a URL for the request.

## How
If generating a URL fails, we throw an error instead of aborting, this allows us to call the completionHandler with the error and complete the operation.

## Reviewers

