### PR TITLE
Add hook for data seralisation

### DIFF
--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -267,16 +267,16 @@ public class QueryViewOperation: CouchDatabaseOperation {
                 items.append(NSURLQueryItem(name: "descending", value: "\(descending)"))
             }
             
-            if let startKey = startKey {
-                items.append(NSURLQueryItem(name: "startkey", value: convertJson(key: startKey)))
+            if let startKeyJson = startKeyJson  {
+                items.append(NSURLQueryItem(name: "startkey", value: startKeyJson))
             }
             
             if let startKeyDocId = startKeyDocId {
                 items.append(NSURLQueryItem(name: "startkey_docid", value: "\(startKeyDocId)"))
             }
             
-            if let endKey = endKey {
-                items.append(NSURLQueryItem(name: "endkey", value: convertJson(key: endKey)))
+            if let endKeyJson = endKeyJson {
+                items.append(NSURLQueryItem(name: "endkey", value: endKeyJson))
             }
             
             if let endKeyDocId = endKeyDocId {
@@ -287,8 +287,8 @@ public class QueryViewOperation: CouchDatabaseOperation {
                 items.append(NSURLQueryItem(name: "inclusive_end", value: "\(inclusiveEnd)"))
             }
             
-            if let key = key {
-                items.append(NSURLQueryItem(name: "key", value: convertJson(key: key)))
+            if let keyJson = keyJson {
+                items.append(NSURLQueryItem(name: "key", value: keyJson))
             }
             
             if let limit = limit {
@@ -323,6 +323,24 @@ public class QueryViewOperation: CouchDatabaseOperation {
         }
     }
     
+    private var keyJson: String?
+    private var endKeyJson: String?
+    private var startKeyJson: String?
+    
+    public override func serialise() throws {
+        if let key = key {
+            keyJson = try convertJson(key: key)
+        }
+        if let endKey = endKey {
+            endKeyJson = try convertJson(key: endKey)
+        }
+        
+        if let startKey = startKey {
+            startKeyJson = try convertJson(key: startKey)
+        }
+        
+    }
+    
     public override func callCompletionHandler(error: ErrorProtocol) {
         self.completionHandler?(response:nil, httpInfo:nil, error: error)
     }
@@ -334,15 +352,10 @@ public class QueryViewOperation: CouchDatabaseOperation {
         }
     }
     
-    func convertJson(key: AnyObject) -> String {
+    func convertJson(key: AnyObject) throws -> String {
         if NSJSONSerialization.isValidJSONObject(key) {
-            do {
-                let keyJson = try NSJSONSerialization.data(withJSONObject: key)
-                return String(data: keyJson , encoding: NSUTF8StringEncoding)!
-            } catch {
-                callCompletionHandler(error: error)
-                return ""
-            }
+            let keyJson = try NSJSONSerialization.data(withJSONObject: key)
+            return String(data: keyJson , encoding: NSUTF8StringEncoding)!
         } else if key is String {
             // we need to quote JSON primitive strings
             return "\"\(key)\""

--- a/Tests/QueryViewTests.swift
+++ b/Tests/QueryViewTests.swift
@@ -59,7 +59,7 @@ public class QueryViewTests : XCTestCase {
         super.tearDown()
     }
     
-    func testViewGeneratesCorrectRequestUsingStartAndEndKeys(){
+    func testViewGeneratesCorrectRequestUsingStartAndEndKeys() throws {
         let view = QueryViewOperation()
         view.designDoc = "ddoc"
         view.viewName = "view1"
@@ -74,6 +74,8 @@ public class QueryViewTests : XCTestCase {
         view.databaseName = self.dbName
         
         XCTAssert(view.validate())
+        try view.serialise()
+        
         XCTAssertEqual("GET",view.httpMethod)
         XCTAssertNil(view.httpRequestBody)
         XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
@@ -90,7 +92,7 @@ public class QueryViewTests : XCTestCase {
         XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
     }
     
-    func testViewGeneratesCorrectRequestUsingJsonStartAndEndKeys(){
+    func testViewGeneratesCorrectRequestUsingJsonStartAndEndKeys() throws {
         let view = QueryViewOperation()
         view.designDoc = "ddoc"
         view.viewName = "view1"
@@ -105,6 +107,8 @@ public class QueryViewTests : XCTestCase {
         view.databaseName = self.dbName
         
         XCTAssert(view.validate())
+        try view.serialise()
+
         XCTAssertEqual("GET",view.httpMethod)
         XCTAssertNil(view.httpRequestBody)
         XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)
@@ -121,7 +125,7 @@ public class QueryViewTests : XCTestCase {
         XCTAssert(expectedQueryItems.isEquivalent(to: view.queryItems))
     }
     
-    func testViewGeneratesCorrectRequestUsingKey(){
+    func testViewGeneratesCorrectRequestUsingKey() throws {
         let view = QueryViewOperation()
         view.designDoc = "ddoc"
         view.viewName = "view1"
@@ -135,6 +139,8 @@ public class QueryViewTests : XCTestCase {
         view.databaseName = self.dbName
         
         XCTAssert(view.validate())
+        try view.serialise()
+        
         XCTAssertEqual("GET",view.httpMethod)
         XCTAssertNil(view.httpRequestBody)
         XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1",view.httpPath)


### PR DESCRIPTION
## What
Make it possible for operations to complete the operation with error when data serialisation fails

## How
Added new `serialise` hook which is a throwing function which allows operations to error when attempting to transform the data to json.

## Reviewers
