### PR TITLE
Move callCompletionHandler implementation to CouchOperation

### DIFF
--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -187,7 +187,7 @@ public class CouchOperation : NSOperation, HTTPRequestOperation
      Subclasses need to override this to call the completion handler they have defined.
      */
     public func callCompletionHandler(error:ErrorProtocol){
-        return
+        self.completionHandler?(response: nil, httpInfo: nil, error: error)
     }
     
     /**

--- a/Source/CreateDatabaseOperation.swift
+++ b/Source/CreateDatabaseOperation.swift
@@ -46,8 +46,4 @@ public class CreateDatabaseOperation : CouchOperation {
         return super.validate() && self.databaseName != nil // should work iirc
     }
     
-    override public func callCompletionHandler(error: ErrorProtocol) {
-        self.completionHandler?(response:nil, httpInfo: nil, error: error)
-    }
-    
 }

--- a/Source/DeleteDatabaseOperation.swift
+++ b/Source/DeleteDatabaseOperation.swift
@@ -46,8 +46,4 @@ public class DeleteDatabaseOperation : CouchOperation {
         return super.validate() && self.databaseName != nil // should work iirc
     }
     
-    public override func callCompletionHandler(error: ErrorProtocol) {
-        self.completionHandler?(response: nil, httpInfo: nil, error: error)
-    }
-    
 }

--- a/Source/DeleteDocumentOperation.swift
+++ b/Source/DeleteDocumentOperation.swift
@@ -66,9 +66,5 @@ public class DeleteDocumentOperation : CouchDatabaseOperation {
     public override var queryItems: [NSURLQueryItem] {
        return [NSURLQueryItem(name: "rev", value: revId!)]
     }
-    
-    public override func callCompletionHandler(error: ErrorProtocol) {
-        self.completionHandler?(response: nil, httpInfo: nil, error: error)
-    }
 
 }

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -68,9 +68,5 @@ public class GetDocumentOperation: CouchDatabaseOperation {
             return items
         }
     }
-    
-    public override func callCompletionHandler(error: ErrorProtocol) {
-        self.completionHandler?(response:nil, httpInfo: nil ,error: error)
-    }
-    
+
 }

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -67,9 +67,5 @@ public class PutDocumentOperation: CouchDatabaseOperation {
             return items
         }
     }
-    
-    public override func callCompletionHandler(error: ErrorProtocol) {
-        completionHandler?(response: nil, httpInfo: nil, error: error)
-    }
 
 }

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -340,11 +340,7 @@ public class QueryViewOperation: CouchDatabaseOperation {
         }
         
     }
-    
-    public override func callCompletionHandler(error: ErrorProtocol) {
-        self.completionHandler?(response:nil, httpInfo:nil, error: error)
-    }
-    
+
     public override func processResponse(json: [String : AnyObject]) {
         let rows = json["rows"] as! [[String:AnyObject]]
         for row:[String:AnyObject] in rows {


### PR DESCRIPTION
## What
Move callCompletionHandler implementation to CouchOperation.

## Why
Now that completionHandlers are common, there is no need for each operation to override the implementation on CouchOperation.

## Reviewers
