### PR TITLE
Add Operation to create attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ create.completionHandler = {(response, httpInfo, error) in
 }
 db.add(operation:create)
 
+// create an attachment
+let attachment = "This is my awesome essay attachment for my document"
+let putAttachment = PutAttachmentOperation()
+putAttachment.docId = "doc1"
+putAttachment.revId = "1-revisionidhere"
+putAttachment.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+putAttachment.attachmentName = "myAwesomeAttachment"
+putAttachment.contentType = "text/plain"
+putAttachment.completionHandler = {(response, info, error) in
+   if let error = error {
+       // handle the error
+   } else {
+       // process successful response
+   }
+}
+database.add(operation: putAttachment)
+
 // Read a document
 let read = GetDocumentOperation()
 read.docId = "doc1"

--- a/Source/PutAttachmentOperation.swift
+++ b/Source/PutAttachmentOperation.swift
@@ -47,7 +47,6 @@ public class PutAttachmentOperation: CouchDatabaseOperation {
     /**
      The id of the document that the attachment should be attached to.
      
-     - Note: mut be set for the attachment operation to successfully run.
      */
     public var docId: String?
     
@@ -73,8 +72,11 @@ public class PutAttachmentOperation: CouchDatabaseOperation {
     
     
     public override func validate() -> Bool {
-        if docId == nil{
-            return false;
+        if !super.validate() {
+            return false
+        }
+        if docId == nil {
+            return false
         }
         
         if revId == nil {
@@ -86,14 +88,14 @@ public class PutAttachmentOperation: CouchDatabaseOperation {
         }
         
         if data == nil {
-            return false;
+            return false
         }
         
         if contentType == nil {
             return false
         }
         
-        return super.validate()
+        return true
     }
     
     public override var httpMethod: String {

--- a/Source/PutAttachmentOperation.swift
+++ b/Source/PutAttachmentOperation.swift
@@ -1,0 +1,119 @@
+//
+//  PutAttachmentOperation.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 11/05/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ 
+ An Operation to add an attachment to a document.
+ 
+ - Requires: All properties defined on this operation to be set.
+ 
+ Example usage:
+ ```
+ let attachment = "This is my awesome essay attachment for my document"
+ let putAttachment = PutAttachmentOperation()
+ putAttachment.docId = docId
+ putAttachment.revId = revId
+ putAttachment.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+ putAttachment.attachmentName = "myAwesomeAttachment"
+ putAttachment.contentType = "text/plain"
+ putAttachment.completionHandler = {(response, info, error) in
+    if let error = error {
+        // handle the error
+    } else {
+        // process successful response
+    }
+ }
+ database.add(operation: putAttachment)
+ 
+ 
+ */
+public class PutAttachmentOperation: CouchDatabaseOperation {
+    
+    /**
+     The id of the document that the attachment should be attached to.
+     
+     - Note: mut be set for the attachment operation to successfully run.
+     */
+    public var docId: String?
+    
+    /**
+     The revision of the document that the attachment should be attached to.
+    */
+    public var revId: String?
+    
+    /**
+     The name of the attachment.
+     */
+    public var attachmentName: String?
+    
+    /**
+     The attachment's data.
+    */
+    public var data: NSData?
+    
+    /**
+     The Content type for the attachment such as text/plain, image/jpeg
+     */
+    public var contentType: String?
+    
+    
+    public override func validate() -> Bool {
+        if docId == nil{
+            return false;
+        }
+        
+        if revId == nil {
+            return false
+        }
+        
+        if attachmentName == nil {
+            return false
+        }
+        
+        if data == nil {
+            return false;
+        }
+        
+        if contentType == nil {
+            return false
+        }
+        
+        return super.validate()
+    }
+    
+    public override var httpMethod: String {
+        return "PUT"
+    }
+    
+    public override var httpPath: String {
+        return "/\(self.databaseName!)/\(docId!)/\(attachmentName!)"
+    }
+    
+    public override var queryItems: [NSURLQueryItem] {
+        return [NSURLQueryItem(name: "rev", value: revId)]
+    }
+    
+    public override var httpRequestBody: NSData? {
+        return data
+    }
+    
+    public override var httpContentType: String {
+        return contentType!
+    }
+    
+}

--- a/SwiftCloudant.xcodeproj/project.pbxproj
+++ b/SwiftCloudant.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		9855CF861CC8CE5F00ED28DA /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */; };
 		9855CF821CC7C5D100ED28DA /* FindDocumentsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF811CC7C5D100ED28DA /* FindDocumentsOperation.swift */; };
 		9855CF841CC7E3DB00ED28DA /* FindDocumentOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF831CC7E3DB00ED28DA /* FindDocumentOperationTests.swift */; };
+		98593EE41CE373CA008F365F /* PutAttachmentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */; };
+		98593EE61CE378A7008F365F /* PutAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98593EE51CE378A7008F365F /* PutAttachmentTests.swift */; };
 		98734A211C88FDB200E79C5B /* SwiftCloudant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98734A171C88FDB200E79C5B /* SwiftCloudant.framework */; };
 		98734A4F1C8A600600E79C5B /* CouchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A401C8A600600E79C5B /* CouchClient.swift */; };
 		98734A501C8A600600E79C5B /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A411C8A600600E79C5B /* Database.swift */; };
@@ -66,6 +68,8 @@
 		9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		9855CF811CC7C5D100ED28DA /* FindDocumentsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FindDocumentsOperation.swift; path = Source/FindDocumentsOperation.swift; sourceTree = SOURCE_ROOT; };
 		9855CF831CC7E3DB00ED28DA /* FindDocumentOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindDocumentOperationTests.swift; sourceTree = "<group>"; };
+		98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PutAttachmentOperation.swift; path = Source/PutAttachmentOperation.swift; sourceTree = SOURCE_ROOT; };
+		98593EE51CE378A7008F365F /* PutAttachmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PutAttachmentTests.swift; sourceTree = "<group>"; };
 		98734A171C88FDB200E79C5B /* SwiftCloudant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCloudant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98734A201C88FDB200E79C5B /* SwiftCloudantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCloudantTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		98734A401C8A600600E79C5B /* CouchClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouchClient.swift; sourceTree = "<group>"; };
@@ -159,6 +163,7 @@
 				9855CF771CC6459E00ED28DA /* DeleteDocumentOperation.swift */,
 				9855CF781CC6459E00ED28DA /* GetDocumentOperation.swift */,
 				9855CF791CC6459E00ED28DA /* PutDocumentOperation.swift */,
+				98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -177,6 +182,7 @@
 				9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */,
 				98FAABBD1CD89F7D0087FF57 /* TestSettings.plist */,
 				9855CF831CC7E3DB00ED28DA /* FindDocumentOperationTests.swift */,
+				98593EE51CE378A7008F365F /* PutAttachmentTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -365,6 +371,7 @@
 				9855CF721CC6458F00ED28DA /* URLSession.swift in Sources */,
 				9855CF701CC6458F00ED28DA /* RequestExecutor.swift in Sources */,
 				9855CF7B1CC6459E00ED28DA /* CouchOperation.swift in Sources */,
+				98593EE41CE373CA008F365F /* PutAttachmentOperation.swift in Sources */,
 				9855CF711CC6458F00ED28DA /* SessionCookieInterceptor.swift in Sources */,
 				2E79FE9C1CDA2BF500AD20E2 /* QueryViewOperation.swift in Sources */,
 				9855CF801CC6459E00ED28DA /* PutDocumentOperation.swift in Sources */,
@@ -389,6 +396,7 @@
 				98734A621C8A601400E79C5B /* GetDocumentTests.swift in Sources */,
 				98734A641C8A601400E79C5B /* SwiftCloudantTests.swift in Sources */,
 				9855CF841CC7E3DB00ED28DA /* FindDocumentOperationTests.swift in Sources */,
+				98593EE61CE378A7008F365F /* PutAttachmentTests.swift in Sources */,
 				98E5431C1C9CCD0500F02E06 /* InterceptorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/PutAttachmentTests.swift
+++ b/Tests/PutAttachmentTests.swift
@@ -1,0 +1,200 @@
+//
+//  File.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 11/05/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+class PutAttachmentTests : XCTestCase {
+    
+    var dbName: String? = nil
+    var client: CouchDBClient? = nil
+    let docId: String = "PutAttachmentTests"
+    var revId: String?
+    
+    override func setUp() {
+        super.setUp()
+        
+        dbName = generateDBName()
+        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        createDatabase(databaseName: dbName!, client: client!)
+        let createDoc = PutDocumentOperation()
+        createDoc.body = createTestDocuments(count: 1).first
+        createDoc.docId = docId
+        createDoc.completionHandler = {[weak self] (response, info, error) in
+                self?.revId = response?["rev"] as? String
+        }
+        client?[dbName!].add(operation: createDoc)
+        createDoc.waitUntilFinished()
+    }
+    
+    override func tearDown() {
+        deleteDatabase(databaseName: dbName!, client: client!)
+        
+        super.tearDown()
+        
+        print("Deleted database: \(dbName!)")
+    }
+    
+    
+    func testPutAttachment() {
+        let putExpect = self.expectation(withDescription: "put attachment")
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.attachmentName = "myAwesomeAttachment"
+        put.contentType = "text/plain"
+        put.completionHandler = {(response, info, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(info)
+            if let info = info {
+                XCTAssert(info.statusCode / 100 == 2)
+            }
+            XCTAssertNotNil(response)
+            
+            putExpect.fulfill()
+        }
+        client?[dbName!].add(operation: put)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+        
+    }
+    
+    func testPutAttachmentValidationMissingData() {
+        let putExpect = self.expectation(withDescription: "put attachment")
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.attachmentName = "myAwesomeAttachment"
+        put.contentType = "text/plain"
+        put.completionHandler = {(response, info, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(info)
+            XCTAssertNil(response)
+            
+            putExpect.fulfill()
+        }
+        client?[dbName!].add(operation: put)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testPutAttachmentValidationMissingRev() {
+        let putExpect = self.expectation(withDescription: "put attachment")
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.attachmentName = "myAwesomeAttachment"
+        put.contentType = "text/plain"
+        put.completionHandler = {(response, info, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(info)
+            XCTAssertNil(response)
+            
+            putExpect.fulfill()
+        }
+        client?[dbName!].add(operation: put)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testPutAttachmentValidationMissingId() {
+        let putExpect = self.expectation(withDescription: "put attachment")
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.revId = revId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.attachmentName = "myAwesomeAttachment"
+        put.contentType = "text/plain"
+        put.completionHandler = {(response, info, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(info)
+            XCTAssertNil(response)
+            
+            putExpect.fulfill()
+        }
+        client?[dbName!].add(operation: put)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testPutAttachmentValidationMissingName() {
+        let putExpect = self.expectation(withDescription: "put attachment")
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.contentType = "text/plain"
+        put.completionHandler = {(response, info, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(info)
+            XCTAssertNil(response)
+            
+            putExpect.fulfill()
+        }
+        client?[dbName!].add(operation: put)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testPutAttachmentValidationMissingContentType() {
+        let putExpect = self.expectation(withDescription: "put attachment")
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.attachmentName = "myAwesomeAttachment"
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.completionHandler = {(response, info, error) in
+            XCTAssertNotNil(error)
+            XCTAssertNil(info)
+            XCTAssertNil(response)
+            
+            putExpect.fulfill()
+        }
+        client?[dbName!].add(operation: put)
+        
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testPutAttachmentHTTPOperationProperties(){
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.attachmentName = "myAwesomeAttachment"
+        put.contentType = "text/plain"
+        put.databaseName = self.dbName
+        XCTAssertTrue(put.validate())
+        XCTAssertTrue(put.queryItems.isEquivalent(to: [NSURLQueryItem(name: "rev", value: revId)]))
+        XCTAssertEqual("/\(self.dbName!)/\(docId)/myAwesomeAttachment", put.httpPath)
+        XCTAssertEqual("PUT", put.httpMethod)
+        XCTAssertEqual(put.data, put.httpRequestBody)
+        XCTAssertEqual(put.contentType, put.httpContentType)
+    }
+
+    
+    
+    
+    
+
+}
+

--- a/Tests/PutAttachmentTests.swift
+++ b/Tests/PutAttachmentTests.swift
@@ -45,20 +45,12 @@ class PutAttachmentTests : XCTestCase {
         deleteDatabase(databaseName: dbName!, client: client!)
         
         super.tearDown()
-        
-        print("Deleted database: \(dbName!)")
     }
     
     
     func testPutAttachment() {
         let putExpect = self.expectation(withDescription: "put attachment")
-        let attachment = "This is my awesome essay attachment for my document"
-        let put = PutAttachmentOperation()
-        put.docId = docId
-        put.revId = revId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
-        put.attachmentName = "myAwesomeAttachment"
-        put.contentType = "text/plain"
+        let put = self.createPutAttachmentOperation()
         put.completionHandler = {(response, info, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(info)
@@ -77,11 +69,8 @@ class PutAttachmentTests : XCTestCase {
     
     func testPutAttachmentValidationMissingData() {
         let putExpect = self.expectation(withDescription: "put attachment")
-        let put = PutAttachmentOperation()
-        put.docId = docId
-        put.revId = revId
-        put.attachmentName = "myAwesomeAttachment"
-        put.contentType = "text/plain"
+        let put = self.createPutAttachmentOperation()
+        put.data = nil
         put.completionHandler = {(response, info, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(info)
@@ -96,12 +85,8 @@ class PutAttachmentTests : XCTestCase {
     
     func testPutAttachmentValidationMissingRev() {
         let putExpect = self.expectation(withDescription: "put attachment")
-        let attachment = "This is my awesome essay attachment for my document"
-        let put = PutAttachmentOperation()
-        put.docId = docId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
-        put.attachmentName = "myAwesomeAttachment"
-        put.contentType = "text/plain"
+        let put = self.createPutAttachmentOperation()
+        put.revId = nil
         put.completionHandler = {(response, info, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(info)
@@ -116,12 +101,8 @@ class PutAttachmentTests : XCTestCase {
     
     func testPutAttachmentValidationMissingId() {
         let putExpect = self.expectation(withDescription: "put attachment")
-        let attachment = "This is my awesome essay attachment for my document"
-        let put = PutAttachmentOperation()
-        put.revId = revId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
-        put.attachmentName = "myAwesomeAttachment"
-        put.contentType = "text/plain"
+        let put = self.createPutAttachmentOperation()
+        put.docId = nil
         put.completionHandler = {(response, info, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(info)
@@ -136,12 +117,8 @@ class PutAttachmentTests : XCTestCase {
     
     func testPutAttachmentValidationMissingName() {
         let putExpect = self.expectation(withDescription: "put attachment")
-        let attachment = "This is my awesome essay attachment for my document"
-        let put = PutAttachmentOperation()
-        put.docId = docId
-        put.revId = revId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
-        put.contentType = "text/plain"
+        let put = self.createPutAttachmentOperation()
+        put.attachmentName = nil
         put.completionHandler = {(response, info, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(info)
@@ -156,12 +133,8 @@ class PutAttachmentTests : XCTestCase {
     
     func testPutAttachmentValidationMissingContentType() {
         let putExpect = self.expectation(withDescription: "put attachment")
-        let attachment = "This is my awesome essay attachment for my document"
-        let put = PutAttachmentOperation()
-        put.docId = docId
-        put.revId = revId
-        put.attachmentName = "myAwesomeAttachment"
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        let put = self.createPutAttachmentOperation()
+        put.contentType = nil
         put.completionHandler = {(response, info, error) in
             XCTAssertNotNil(error)
             XCTAssertNil(info)
@@ -175,13 +148,7 @@ class PutAttachmentTests : XCTestCase {
     }
     
     func testPutAttachmentHTTPOperationProperties(){
-        let attachment = "This is my awesome essay attachment for my document"
-        let put = PutAttachmentOperation()
-        put.docId = docId
-        put.revId = revId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
-        put.attachmentName = "myAwesomeAttachment"
-        put.contentType = "text/plain"
+        let put = self.createPutAttachmentOperation()
         put.databaseName = self.dbName
         XCTAssertTrue(put.validate())
         XCTAssertTrue(put.queryItems.isEquivalent(to: [NSURLQueryItem(name: "rev", value: revId)]))
@@ -191,7 +158,16 @@ class PutAttachmentTests : XCTestCase {
         XCTAssertEqual(put.contentType, put.httpContentType)
     }
 
-    
+    func createPutAttachmentOperation() -> PutAttachmentOperation {
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.attachmentName = "myAwesomeAttachment"
+        put.contentType = "text/plain"
+        return put
+    }
     
     
     


### PR DESCRIPTION
## What
Add the ability to create attachments for a document on the remote server.

## How
Created PutAttachmentOperation which contains the functionality to upload attachments to the server.

## Reviewers
reviewer @ricellis

## Issues 

Fixes #63