### PR TITLE
Add DeleteAttachmentOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [NEW] New FindDocumentsOperation API.
+- [NEW] New DeleteAttachmentOperation API.
 
 # 0.2.1 (2016-05-13)
 

--- a/Source/AttachmentOperation.swift
+++ b/Source/AttachmentOperation.swift
@@ -1,0 +1,72 @@
+//
+//  AttachmentOperation.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 23/05/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ - warning: This class is **not** to be used directly, it only acts as a base for attachment operations
+ */
+public class AttachmentOperation: CouchDatabaseOperation {
+    
+    /**
+     The id of the document that the attachment should be attached to.
+     
+     */
+    public var docId: String?
+    
+    /**
+     The revision of the document that the attachment should be attached to.
+     */
+    public var revId: String?
+    
+    /**
+     The name of the attachment.
+     */
+    public var attachmentName: String?
+    
+    public override func validate() -> Bool {
+        if !super.validate() {
+            return false
+        }
+        if docId == nil {
+            return false
+        }
+        
+        if revId == nil {
+            return false
+        }
+        
+        if attachmentName == nil {
+            return false
+        }
+        
+        return true
+    }
+    
+    public override var httpPath: String {
+        return "/\(self.databaseName!)/\(docId!)/\(attachmentName!)"
+    }
+    
+    public override var queryItems: [NSURLQueryItem] {
+        return [NSURLQueryItem(name: "rev", value: revId)]
+    }
+    
+    public override var httpMethod: String {
+        return "HEAD"
+    }
+    
+    
+}

--- a/Source/DeleteAttachmentOperation.swift
+++ b/Source/DeleteAttachmentOperation.swift
@@ -1,0 +1,48 @@
+//
+//  DeleteAttachmentOperation.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 17/05/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ 
+ An Operation to delete an attachment from a document.
+ 
+ - Requires: All properties defined on this operation to be set.
+ 
+ Example usage:
+ ```
+ let deleteAttachment = DeleteAttachmentOperation()
+ deleteAttachment.docId = docId
+ deleteAttachment.revId = revId
+ deleteAttachment.attachmentName = "myAwesomeAttachment"
+ deleteAttachment.completionHandler = {(response, info, error) in
+ if let error = error {
+ // handle the error
+ } else {
+ // process successful response
+ }
+ }
+ database.add(operation: deleteAttachment)
+ ```
+ 
+ */
+public class DeleteAttachmentOperation: AttachmentOperation {
+
+    public override var httpMethod: String {
+        return "DELETE"
+    }
+
+}

--- a/Source/PutAttachmentOperation.swift
+++ b/Source/PutAttachmentOperation.swift
@@ -39,26 +39,10 @@ import Foundation
     }
  }
  database.add(operation: putAttachment)
- 
+ ```
  
  */
-public class PutAttachmentOperation: CouchDatabaseOperation {
-    
-    /**
-     The id of the document that the attachment should be attached to.
-     
-     */
-    public var docId: String?
-    
-    /**
-     The revision of the document that the attachment should be attached to.
-    */
-    public var revId: String?
-    
-    /**
-     The name of the attachment.
-     */
-    public var attachmentName: String?
+public class PutAttachmentOperation: AttachmentOperation {
     
     /**
      The attachment's data.
@@ -75,17 +59,6 @@ public class PutAttachmentOperation: CouchDatabaseOperation {
         if !super.validate() {
             return false
         }
-        if docId == nil {
-            return false
-        }
-        
-        if revId == nil {
-            return false
-        }
-        
-        if attachmentName == nil {
-            return false
-        }
         
         if data == nil {
             return false
@@ -100,14 +73,6 @@ public class PutAttachmentOperation: CouchDatabaseOperation {
     
     public override var httpMethod: String {
         return "PUT"
-    }
-    
-    public override var httpPath: String {
-        return "/\(self.databaseName!)/\(docId!)/\(attachmentName!)"
-    }
-    
-    public override var queryItems: [NSURLQueryItem] {
-        return [NSURLQueryItem(name: "rev", value: revId)]
     }
     
     public override var httpRequestBody: NSData? {

--- a/SwiftCloudant.xcodeproj/project.pbxproj
+++ b/SwiftCloudant.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2E79FE9C1CDA2BF500AD20E2 /* QueryViewOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */; };
 		2E79FE9E1CDA2C0900AD20E2 /* QueryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E79FE9D1CDA2C0900AD20E2 /* QueryViewTests.swift */; };
 		980A04941CEC56B000F5F049 /* DeleteQueryIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */; };
+		980A04901CEB739700F5F049 /* DeleteAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A048F1CEB739700F5F049 /* DeleteAttachmentTests.swift */; };
 		9855CF6F1CC6458F00ED28DA /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6B1CC6458F00ED28DA /* RequestBuilder.swift */; };
 		9855CF701CC6458F00ED28DA /* RequestExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6C1CC6458F00ED28DA /* RequestExecutor.swift */; };
 		9855CF711CC6458F00ED28DA /* SessionCookieInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6D1CC6458F00ED28DA /* SessionCookieInterceptor.swift */; };
@@ -40,6 +41,8 @@
 		98C175ED1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C175EC1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift */; };
 		98D129601CF3095E00CF7219 /* GetAllDatabasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */; };
 		98D129661CF3318800CF7219 /* GetAllDatabasesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D129651CF3318800CF7219 /* GetAllDatabasesOperation.swift */; };
+		98D129641CF32D8E00CF7219 /* AttachmentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D129631CF32D8E00CF7219 /* AttachmentOperation.swift */; };
+		98E148CF1CF73E81006FE90E /* DeleteAttachmentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E148CE1CF73E81006FE90E /* DeleteAttachmentOperation.swift */; };
 		98E5431C1C9CCD0500F02E06 /* InterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */; };
 		98EC4AE81CC1533800704CFE /* DeleteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EC4AE61CC1531200704CFE /* DeleteDocumentTests.swift */; };
 		98FAABBE1CD89F7D0087FF57 /* TestSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 98FAABBD1CD89F7D0087FF57 /* TestSettings.plist */; };
@@ -61,6 +64,7 @@
 		2E79FE9D1CDA2C0900AD20E2 /* QueryViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryViewTests.swift; sourceTree = "<group>"; };
 		7F96FB133EC7F68F6BF31CC3 /* Pods_SwiftCloudantTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftCloudantTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteQueryIndexTests.swift; sourceTree = "<group>"; };
+		980A048F1CEB739700F5F049 /* DeleteAttachmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteAttachmentTests.swift; sourceTree = "<group>"; };
 		9855CF6B1CC6458F00ED28DA /* RequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestBuilder.swift; path = Source/RequestBuilder.swift; sourceTree = SOURCE_ROOT; };
 		9855CF6C1CC6458F00ED28DA /* RequestExecutor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestExecutor.swift; path = Source/RequestExecutor.swift; sourceTree = SOURCE_ROOT; };
 		9855CF6D1CC6458F00ED28DA /* SessionCookieInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SessionCookieInterceptor.swift; path = Source/SessionCookieInterceptor.swift; sourceTree = SOURCE_ROOT; };
@@ -93,6 +97,8 @@
 		98C175EC1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeleteQueryIndexOperation.swift; path = Source/DeleteQueryIndexOperation.swift; sourceTree = SOURCE_ROOT; };
 		98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetAllDatabasesTests.swift; sourceTree = "<group>"; };
 		98D129651CF3318800CF7219 /* GetAllDatabasesOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GetAllDatabasesOperation.swift; path = Source/GetAllDatabasesOperation.swift; sourceTree = SOURCE_ROOT; };
+		98D129631CF32D8E00CF7219 /* AttachmentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttachmentOperation.swift; path = Source/AttachmentOperation.swift; sourceTree = SOURCE_ROOT; };
+		98E148CE1CF73E81006FE90E /* DeleteAttachmentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeleteAttachmentOperation.swift; path = Source/DeleteAttachmentOperation.swift; sourceTree = SOURCE_ROOT; };
 		98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterceptorTests.swift; sourceTree = "<group>"; };
 		98EC4AE61CC1531200704CFE /* DeleteDocumentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteDocumentTests.swift; sourceTree = "<group>"; };
 		98FAABBD1CD89F7D0087FF57 /* TestSettings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TestSettings.plist; sourceTree = "<group>"; };
@@ -168,6 +174,7 @@
 			children = (
 				98D129651CF3318800CF7219 /* GetAllDatabasesOperation.swift */,
 				98C175EC1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift */,
+				98E148CE1CF73E81006FE90E /* DeleteAttachmentOperation.swift */,
 				2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */,
 				9855CF811CC7C5D100ED28DA /* FindDocumentsOperation.swift */,
 				9855CF731CC6459E00ED28DA /* CouchDatabaseOperation.swift */,
@@ -179,6 +186,7 @@
 				9855CF791CC6459E00ED28DA /* PutDocumentOperation.swift */,
 				98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */,
 				988A746C1CECC25A00242C24 /* CreateQueryIndexOperation.swift */,
+				98D129631CF32D8E00CF7219 /* AttachmentOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -201,6 +209,7 @@
 				980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */,
 				98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */,
 				988A746E1CECC26B00242C24 /* CreateQueryIndexTests.swift */,
+				980A048F1CEB739700F5F049 /* DeleteAttachmentTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -391,6 +400,8 @@
 				9855CF701CC6458F00ED28DA /* RequestExecutor.swift in Sources */,
 				9855CF7B1CC6459E00ED28DA /* CouchOperation.swift in Sources */,
 				98593EE41CE373CA008F365F /* PutAttachmentOperation.swift in Sources */,
+				98E148CF1CF73E81006FE90E /* DeleteAttachmentOperation.swift in Sources */,
+				98D129641CF32D8E00CF7219 /* AttachmentOperation.swift in Sources */,
 				9855CF711CC6458F00ED28DA /* SessionCookieInterceptor.swift in Sources */,
 				2E79FE9C1CDA2BF500AD20E2 /* QueryViewOperation.swift in Sources */,
 				9855CF801CC6459E00ED28DA /* PutDocumentOperation.swift in Sources */,
@@ -410,6 +421,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				988A746F1CECC26B00242C24 /* CreateQueryIndexTests.swift in Sources */,
+				980A04901CEB739700F5F049 /* DeleteAttachmentTests.swift in Sources */,
 				98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */,
 				98EC4AE81CC1533800704CFE /* DeleteDocumentTests.swift in Sources */,
 				9855CF861CC8CE5F00ED28DA /* TestHelpers.swift in Sources */,

--- a/Tests/DeleteAttachmentTests.swift
+++ b/Tests/DeleteAttachmentTests.swift
@@ -1,0 +1,126 @@
+//
+//  DeleteAttachmentTests.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 17/05/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+class DeleteAttachmentTests : XCTestCase {
+    
+    var dbName: String? = nil
+    var client: CouchDBClient? = nil
+    let docId: String = "PutAttachmentTests"
+    var revId: String?
+    
+    override func setUp() {
+        super.setUp()
+        
+        dbName = generateDBName()
+        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        createDatabase(databaseName: dbName!, client: client!)
+        let createDoc = PutDocumentOperation()
+        createDoc.body = createTestDocuments(count: 1).first
+        createDoc.docId = docId
+        createDoc.completionHandler = {[weak self] (response, info, error) in
+            self?.revId = response?["rev"] as? String
+        }
+        client?[dbName!].add(operation: createDoc)
+        createDoc.waitUntilFinished()
+        
+        let attachment = "This is my awesome essay attachment for my document"
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.attachmentName = "myAwesomeAttachment"
+        put.contentType = "text/plain"
+        put.completionHandler = {[weak self] (response, info, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(info)
+            if let info = info {
+                XCTAssert(info.statusCode / 100 == 2)
+            }
+            XCTAssertNotNil(response)
+            self?.revId = response?["rev"] as? String
+            
+        }
+        client?[dbName!].add(operation: put)
+        put.waitUntilFinished()
+    }
+    
+    override func tearDown() {
+        deleteDatabase(databaseName: dbName!, client: client!)
+        
+        super.tearDown()
+    }
+    
+    func testDeleteAttachment(){
+        let deleteExpectation = self.expectation(withDescription: "Delete expectation")
+        let delete = DeleteAttachmentOperation()
+        delete.docId = docId
+        delete.revId = revId
+        delete.attachmentName = "myAwesomeAttachment"
+        delete.databaseName = self.dbName
+        delete.completionHandler = { (response, info, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(info)
+            if let info = info {
+                XCTAssert(info.statusCode / 100 == 2)
+            }
+            XCTAssertNotNil(response)
+            deleteExpectation.fulfill()
+        }
+        client?[dbName!].add(operation: delete)
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testDeleteAttachmentValidationMissingId() {
+        let delete = DeleteAttachmentOperation()
+        delete.revId = revId
+        delete.attachmentName = "myAwesomeAttachment"
+        delete.databaseName = self.dbName
+        XCTAssertFalse(delete.validate())
+    }
+    
+    func testDeleteAttachmentValidationMissingRev() {
+        let delete = DeleteAttachmentOperation()
+        delete.docId = docId
+        delete.attachmentName = "myAwesomeAttachment"
+        delete.databaseName = self.dbName
+        XCTAssertFalse(delete.validate())
+    }
+    
+    func testDeleteAttachmentValidationMissingName() {
+        let delete = DeleteAttachmentOperation()
+        delete.docId = docId
+        delete.revId = revId
+        delete.databaseName = self.dbName
+        XCTAssertFalse(delete.validate())
+    }
+    
+    func testDeleteAttachmentHTTPOperationProperties(){
+        let delete = DeleteAttachmentOperation()
+        delete.docId = docId
+        delete.revId = revId
+        delete.attachmentName = "myAwesomeAttachment"
+        delete.databaseName = self.dbName
+        XCTAssertTrue(delete.validate())
+        XCTAssertTrue(delete.queryItems.isEquivalent(to: [NSURLQueryItem(name: "rev", value: revId)]))
+        XCTAssertEqual("/\(self.dbName!)/\(docId)/myAwesomeAttachment", delete.httpPath)
+        XCTAssertEqual("DELETE", delete.httpMethod)
+    }
+
+}


### PR DESCRIPTION
## What
Add DeleteAttachmentOperation.
## How
Added DeleteAttachmentOperation, the properties required for this is a subset of
PutAttachmentOperation, so DeleteAttachmentOperation becomes the super class for
PutAttachment adding the needed properties.

## Testing
New tests added to DeleteAttachmentTests

## Reviewers
reviewer: @brynh
## Issues

Fixes #65