### PR TITLE
Add ability to create Query (Mango) Indexes.

### DIFF
--- a/Source/CreateQueryIndexOperation.swift
+++ b/Source/CreateQueryIndexOperation.swift
@@ -1,0 +1,289 @@
+//
+//  CreateQueryIndexOperation.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 18/05/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+
+import Foundation
+
+/**
+    An operation to create a JSON Query (Mango) Index.
+ 
+    Usage example:
+    ```
+    let index = CreateJsonQueryIndexOperation()
+    index.indexName = "exampleIndex"
+    index.fields = [Sort(field:"food", sort: .Desc)]
+    index.designDoc = "examples"
+    index.completionHandler = { (response, httpInfo, error) in
+        if let error = error {
+            // handle the error
+        } else {
+            // Check the status code for success.
+        }
+ 
+    }
+ 
+    database.add(operation: index)
+    ```
+ */
+public class CreateJsonQueryIndexOperation: CouchDatabaseOperation, MangoOperation {
+    
+    /**
+     The name of the index.
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     */
+    public var indexName: String?
+    
+    /**
+     The fields to which the index will be applied.
+     
+     - Note: Required, this parameter needs to be set for the operation to successfully complete.
+     */
+    public var fields: [Sort]?
+    
+    /**
+     The name of the design doc this index should be saved to.
+     
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     */
+    public var designDoc: String?
+
+    private var jsonData: NSData?
+    
+    
+    public override var httpMethod: String {
+        return "POST"
+    }
+
+    public override var httpRequestBody: NSData? {
+        return self.jsonData
+    }
+    
+    public override var httpPath: String {
+        return "/\(self.databaseName!)/_index"
+    }
+    
+    public override func validate() -> Bool {
+        if !super.validate(){
+            return false
+        }
+        
+        return fields != nil
+    }
+
+    public override func serialise() throws {
+
+        var jsonDict: [String:AnyObject] = ["type": "json"]
+
+        if let fields = fields {
+            var index: [String: AnyObject] = [:]
+            index["fields"] = transform(sortArray: fields) as NSArray
+            jsonDict["index"] = index as NSDictionary
+        }
+
+        if let indexName = indexName {
+            jsonDict["name"] = indexName as NSString
+        }
+
+        if let designDoc = designDoc {
+            jsonDict["ddoc"] = designDoc as NSString
+        }
+
+
+        jsonData = try NSJSONSerialization.data(withJSONObject:jsonDict as NSDictionary) 
+    }
+    
+}
+
+/**
+  A struct to represent a field in a Text index.
+ */
+public struct TextIndexField {
+    /**
+     The name of the field
+    */
+    let name: String
+    /**
+     The type of field.
+     */
+    let type: TextIndexFieldType
+}
+
+/**
+    The data types for a field in a Text index.
+ */
+public enum TextIndexFieldType : String {
+    /**
+     A Boolean data type.
+    */
+    case Boolean = "boolean"
+    /**
+     A String data type.
+    */
+    case String = "string"
+    /**
+     A Number data type.
+    */
+    case Number =  "number"
+}
+
+/**
+ An Operation to create a Text Query (Mango) Index.
+ 
+ Usage Example:
+ ```
+ let index = CreateTextQueryIndexOperation()
+ index.indexName = "example"
+ index.fields = [TextIndexField(name:"food", type: .String)
+ index.defaultFieldAnalyzer = "english"
+ index.defaultFieldEnabled = true
+ index.selector = ["type": "food"]
+ index.designDoc = "examples"
+ index.completionHandler = { (response, httpInfo, error) in 
+    if let error = error {
+        // handle the error
+    } else {
+        // Check the status code for success.
+    }
+ }
+ */
+public class CreateTextQueryIndexOperation: CouchDatabaseOperation, MangoOperation {
+    
+    /**
+     The name of the index
+     
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     */
+    public var indexName: String?
+    
+    /**
+     The fields to be included in the index.
+     
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     */
+    public var fields: [TextIndexField]?
+    
+    /**
+     The name of the analyzer to use for $text operator with this index.
+     
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     */
+    public var defaultFieldAnalyzer: String?
+    
+    /**
+     If the default field should be enabled for this index.
+     
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     
+     - Note: If this is not enabled the `$text` operator will **always** return 0 results.
+     
+     */
+    public var defaultFieldEnabled: Bool?
+    
+    /**
+     A selector to limit the documents in the index.
+     
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     */
+    public var selector: [String: AnyObject]?
+    
+    /**
+     The name of the design doc this index should be included with
+     
+     - Note: Optional, if this parameter is not set, it will be omitted from the request
+     and the server default will apply.
+     */
+    public var designDoc: String?
+
+    private var jsonData : NSData?
+    public override var httpRequestBody: NSData? {
+        return jsonData
+    }
+    
+    public override var httpMethod: String {
+        return "POST"
+    }
+    
+    public override var httpPath: String {
+        return "/\(self.databaseName!)/_index"
+    }
+    
+    public override func validate() -> Bool {
+        if !super.validate() {
+            return false
+        }
+        
+        if let selector = selector {
+            return NSJSONSerialization.isValidJSONObject(selector as NSDictionary)
+        }
+        
+        return true
+    }
+    
+    public override func serialise() throws {
+
+        do {
+            var jsonDict: [String: AnyObject] = [:]
+            var index: [String: AnyObject] = [:]
+            var defaultField: [String: AnyObject] = [:]
+            jsonDict["type"] = "text"
+            
+            if let indexName = indexName {
+                jsonDict["name"] = indexName as NSString
+            }
+            
+            if let fields = fields {
+                index["fields"] = transform(fields: fields)
+            }
+            
+            if let defaultFieldEnabled = defaultFieldEnabled {
+                defaultField["enabled"] = defaultFieldEnabled as NSNumber
+            }
+
+            if let defaultFieldAnalyzer = defaultFieldAnalyzer {
+                defaultField["analyzer"] = defaultFieldAnalyzer as NSString
+            }
+            
+            if let designDoc = designDoc {
+                jsonDict["ddoc"] = designDoc as NSString
+            }
+
+            if let selector = selector {
+                index["selector"] = selector as NSDictionary
+            } 
+
+            if defaultField.count > 0 {
+                index["default_field"] = defaultField as NSDictionary
+            }
+
+            if index.count > 0 {
+                jsonDict["index"] = index as NSDictionary
+            }
+
+            self.jsonData = try NSJSONSerialization.data(withJSONObject:jsonDict as NSDictionary)
+
+        }
+        
+    }
+    
+}
+

--- a/Source/FindDocumentsOperation.swift
+++ b/Source/FindDocumentsOperation.swift
@@ -43,6 +43,46 @@ public struct Sort {
 }
 
 /**
+ Protocol for operations which deal with the Mango API set for CouchDB / Cloudant.
+*/
+internal protocol MangoOperation {
+    
+}
+
+internal extension MangoOperation {
+    /**
+        Transform an Array of Sort into a Array in the form of Sort Syntax.
+    */
+    internal func transform(sortArray: [Sort]) -> [AnyObject] {
+        
+        var transformed: [AnyObject] = []
+        for s in sortArray {
+            if let sort = s.sort {
+                let dict = [s.field: sort.rawValue]
+                transformed.append(dict as NSDictionary)
+            } else {
+                transformed.append(s.field as NSString)
+            }
+        }
+        
+        return transformed
+    }
+
+    /**
+        Transform an array of TextIndexField into an Array in the form of Lucene field definitions.
+    */
+    internal func transform(fields: [TextIndexField]) -> NSArray {
+        var array: [[String:String]] = []
+
+        for field in fields {
+            array.append([field.name: field.type.rawValue])
+        }
+
+        return array as NSArray
+    }
+}
+
+/**
  Usage example:
 
  ```
@@ -64,7 +104,7 @@ public struct Sort {
  
  ```
  */
-public class FindDocumentsOperation: CouchDatabaseOperation {
+public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation {
     /**
      The selector for the query, as a dictionary representation. See
      [the Cloudant documentation](https://docs.cloudant.com/cloudant_query.html#selector-syntax)
@@ -199,6 +239,8 @@ public class FindDocumentsOperation: CouchDatabaseOperation {
         }
         
         if let sort = self.sort {
+            transform(sortArray: sort)
+            
             jsonObj["sort"] = transform(sortArray: sort) as NSArray
         }
         
@@ -217,7 +259,7 @@ public class FindDocumentsOperation: CouchDatabaseOperation {
         return jsonObj
     }
 
-    private func transform(sortArray: [Sort]) -> [AnyObject] {
+    internal class func transform(sortArray: [Sort]) -> [AnyObject] {
 
         var transfomed: [AnyObject] = []
         for s in sortArray {

--- a/SwiftCloudant.xcodeproj/project.pbxproj
+++ b/SwiftCloudant.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		98734A611C8A601400E79C5B /* CreateDatabaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A5D1C8A601400E79C5B /* CreateDatabaseTests.swift */; };
 		98734A621C8A601400E79C5B /* GetDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A5E1C8A601400E79C5B /* GetDocumentTests.swift */; };
 		98734A641C8A601400E79C5B /* SwiftCloudantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A601C8A601400E79C5B /* SwiftCloudantTests.swift */; };
+		988A746D1CECC25A00242C24 /* CreateQueryIndexOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988A746C1CECC25A00242C24 /* CreateQueryIndexOperation.swift */; };
+		988A746F1CECC26B00242C24 /* CreateQueryIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988A746E1CECC26B00242C24 /* CreateQueryIndexTests.swift */; };
 		98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B4F2CD1CA759130076C5E4 /* PutDocumentTests.swift */; };
 		98C175ED1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C175EC1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift */; };
 		98D129601CF3095E00CF7219 /* GetAllDatabasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */; };
@@ -85,6 +87,8 @@
 		98734A5E1C8A601400E79C5B /* GetDocumentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetDocumentTests.swift; sourceTree = "<group>"; };
 		98734A5F1C8A601400E79C5B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		98734A601C8A601400E79C5B /* SwiftCloudantTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftCloudantTests.swift; sourceTree = "<group>"; };
+		988A746C1CECC25A00242C24 /* CreateQueryIndexOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CreateQueryIndexOperation.swift; path = Source/CreateQueryIndexOperation.swift; sourceTree = SOURCE_ROOT; };
+		988A746E1CECC26B00242C24 /* CreateQueryIndexTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateQueryIndexTests.swift; sourceTree = "<group>"; };
 		98B4F2CD1CA759130076C5E4 /* PutDocumentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PutDocumentTests.swift; sourceTree = "<group>"; };
 		98C175EC1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeleteQueryIndexOperation.swift; path = Source/DeleteQueryIndexOperation.swift; sourceTree = SOURCE_ROOT; };
 		98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetAllDatabasesTests.swift; sourceTree = "<group>"; };
@@ -174,6 +178,7 @@
 				9855CF781CC6459E00ED28DA /* GetDocumentOperation.swift */,
 				9855CF791CC6459E00ED28DA /* PutDocumentOperation.swift */,
 				98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */,
+				988A746C1CECC25A00242C24 /* CreateQueryIndexOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -195,6 +200,7 @@
 				98593EE51CE378A7008F365F /* PutAttachmentTests.swift */,
 				980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */,
 				98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */,
+				988A746E1CECC26B00242C24 /* CreateQueryIndexTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -390,6 +396,7 @@
 				9855CF801CC6459E00ED28DA /* PutDocumentOperation.swift in Sources */,
 				9855CF7A1CC6459E00ED28DA /* CouchDatabaseOperation.swift in Sources */,
 				9855CF6F1CC6458F00ED28DA /* RequestBuilder.swift in Sources */,
+				988A746D1CECC25A00242C24 /* CreateQueryIndexOperation.swift in Sources */,
 				98734A501C8A600600E79C5B /* Database.swift in Sources */,
 				98C175ED1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift in Sources */,
 				98734A4F1C8A600600E79C5B /* CouchClient.swift in Sources */,
@@ -402,6 +409,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				988A746F1CECC26B00242C24 /* CreateQueryIndexTests.swift in Sources */,
 				98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */,
 				98EC4AE81CC1533800704CFE /* DeleteDocumentTests.swift in Sources */,
 				9855CF861CC8CE5F00ED28DA /* TestHelpers.swift in Sources */,

--- a/Tests/CreateQueryIndexTests.swift
+++ b/Tests/CreateQueryIndexTests.swift
@@ -1,0 +1,291 @@
+//
+//  CreateQueryIndexTests.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 18/05/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+import XCTest
+import OHHTTPStubs
+@testable import SwiftCloudant
+
+
+public class CreateQueryIndexTests : XCTestCase {
+    
+    var client: CouchDBClient? = nil;
+    var dbName: String? = nil
+    var db: Database? = nil
+    
+    
+    public override func setUp() {
+        super.setUp()
+        
+        dbName = generateDBName()
+        client = CouchDBClient(url: NSURL(string:self.url)!, username: self.username, password: self.password)
+        db = client![dbName!]
+        
+        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            return (request.url?.path?.contains("_index"))! && !(request.httpMethod! == "POST")
+            }, withStubResponse: { (request) -> OHHTTPStubsResponse in
+                OHHTTPStubsResponse(jsonObject: [:], statusCode: 405, headers: [:])
+        })
+        
+        OHHTTPStubs.stubRequests(passingTest: { (request) -> Bool in
+            return (request.url?.path?.contains("_index"))! && (request.httpMethod! == "POST")
+            }, withStubResponse: { (request) -> OHHTTPStubsResponse in
+                OHHTTPStubsResponse(jsonObject: [:], statusCode: 201, headers: ["result": "created"])
+        })
+    }
+    
+    
+    func testCanCreateTextIndexes() {
+        let expectation = self.expectation(withDescription: "create text index")
+        let index = CreateTextQueryIndexOperation()
+        index.completionHandler = { (response, httpStatus, error) in
+            XCTAssertNotNil(response)
+            XCTAssertNotNil(httpStatus)
+            if let httpStatus = httpStatus {
+                XCTAssert(httpStatus.statusCode / 100 == 2)
+            }
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        db?.add(operation: index)
+        self.waitForExpectations(withTimeout:10.0, handler: nil)
+    }
+    
+    func testCanCreateJSONIndexes() {
+        let expectation = self.expectation(withDescription: "create json Index")
+        let index = CreateJsonQueryIndexOperation()
+        index.fields = [Sort(field:"foo", sort:nil)]
+        index.completionHandler = { (response, httpStatus, error) in
+            XCTAssertNotNil(response)
+            XCTAssertNotNil(httpStatus)
+            if let httpStatus = httpStatus {
+                XCTAssert(httpStatus.statusCode / 100 == 2)
+            }
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+        db?.add(operation: index)
+        self.waitForExpectations(withTimeout:10.0, handler: nil)
+    }
+    
+    func testJsonIndexRequestProperties() throws {
+        let index = CreateJsonQueryIndexOperation()
+        index.fields = [Sort(field:"foo", sort:nil)]
+        index.indexName = "indexName"
+        index.designDoc = "ddoc"
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        XCTAssertEqual("POST", index.httpMethod)
+        XCTAssertEqual("/dbname/_index", index.httpPath)
+        XCTAssertEqual([], index.queryItems)
+        
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"json", "index":["fields" : ["foo"]], "name" : "indexName", "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
+        }
+        
+    }
+    
+    func testTextIndexRequestProperties() throws {
+        let index = CreateTextQueryIndexOperation()
+        index.fields = [TextIndexField(name: "foo", type: .String)]
+        index.indexName = "indexName"
+        index.designDoc = "ddoc"
+        index.defaultFieldAnalyzer = "english"
+        index.defaultFieldEnabled = true
+        index.selector = ["bar": "foo"]
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        XCTAssertEqual("POST", index.httpMethod)
+        XCTAssertEqual("/dbname/_index", index.httpPath)
+        XCTAssertEqual([], index.queryItems)
+        
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"text", "index" : [ "selector": ["bar" : "foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]], "name" : "indexName", "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    
+    func testJsonValidationMissingFields(){
+        let index = CreateJsonQueryIndexOperation()
+        index.databaseName = "dbName"
+        XCTAssertFalse(index.validate())
+    }
+    
+    func testJsonEmitsPresentFieldsMissingIndexName() throws  {
+        let index = CreateJsonQueryIndexOperation()
+        index.fields = [Sort(field:"foo", sort:nil)]
+        index.designDoc = "ddoc"
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"json", "index":["fields" : ["foo"]], "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    func testJsonEmitsPresentFieldsMissingddoc() throws {
+        let index = CreateJsonQueryIndexOperation()
+        index.fields = [Sort(field:"foo", sort:nil)]
+        index.indexName = "indexName"
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"json", "index":["fields" : ["foo"]], "name":"indexName"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    func testTextIndexEmitsPresentFieldsMissingIndexName() throws {
+        let index = CreateTextQueryIndexOperation()
+        index.fields = [TextIndexField(name: "foo", type: .String)]
+        index.designDoc = "ddoc"
+        index.defaultFieldAnalyzer = "english"
+        index.defaultFieldEnabled = true
+        index.selector = ["bar": "foo"]
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"text", "index" : ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]], "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    func testTextIndexEmitsPresentFieldsMissingFields() throws {
+        let index = CreateTextQueryIndexOperation()
+        index.indexName = "indexName"
+        index.designDoc = "ddoc"
+        index.defaultFieldAnalyzer = "english"
+        index.defaultFieldEnabled = true
+        index.selector = ["bar": "foo"]
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"text", "name": "indexName", "index" : ["selector":["bar":"foo"], "default_field": ["enabled": true, "analyzer": "english" ]], "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    func testTextIndexEmitsPresentFieldsMissingddoc() throws {
+        let index = CreateTextQueryIndexOperation()
+        index.fields = [TextIndexField(name: "foo", type: .String)]
+        index.indexName = "indexName"
+        index.defaultFieldAnalyzer = "english"
+        index.defaultFieldEnabled = true
+        index.selector = ["bar": "foo"]
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"text", "index" : ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]], "name":"indexName"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    func testTextIndexEmitsPresentFieldsMissinganalyzer() throws {
+        let index = CreateTextQueryIndexOperation()
+        index.fields = [TextIndexField(name: "foo", type: .String)]
+        index.designDoc = "ddoc"
+        index.indexName = "indexName"
+        index.defaultFieldEnabled = true
+        index.selector = ["bar": "foo"]
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"text", "index" : ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true ]], "ddoc":"ddoc", "name": "indexName"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    func testTextIndexEmitsPresentFieldsMissingDefaultFieldEnabled() throws {
+        let index = CreateTextQueryIndexOperation()
+        index.fields = [TextIndexField(name: "foo", type: .String)]
+        index.designDoc = "ddoc"
+        index.defaultFieldAnalyzer = "english"
+        index.indexName = "indexName"
+        index.selector = ["bar": "foo"]
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"text", "index" : [ "selector":["bar":"foo"],"fields" : [["foo":"string"]], "default_field": ["analyzer": "english" ]], "ddoc":"ddoc", "name": "indexName"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+    func testTextIndexEmitsPresentFieldsMissingselector() throws {
+        let index = CreateTextQueryIndexOperation()
+        index.fields = [TextIndexField(name: "foo", type: .String)]
+        index.indexName = "indexName"
+        index.designDoc = "ddoc"
+        index.defaultFieldAnalyzer = "english"
+        index.defaultFieldEnabled = true
+        index.databaseName = "dbname"
+        XCTAssert(index.validate())
+        try index.serialise()
+        // do the json manipulation stuff.
+        let data = index.httpRequestBody
+        
+        XCTAssertNotNil(data)
+        if let data = data {
+            let json = try NSJSONSerialization.jsonObject(with: data)
+            XCTAssertEqual(["type":"text", "index" : [ "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]],"name":"indexName", "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
+        }
+    }
+    
+}


### PR DESCRIPTION
## What
Add the ability to create Query indexes.

## How
- CreateJSONIndexOperation to create a JSON index.
- CreateTextIndexOperation to create a text index.
- Created internal protocol `MangoOperation`
- Refactored the `transform` method from `FindDocumentsOperation` into a protocol extension for `MangoOperation`, this provides the transformation methods to only the operations which interact with Mango / Query. 

This is split into two operations instead of one to make it possible to
have compile time type checking for the `fields` parameter. This makes it
more swift like with type safety.

## Testing

Tests added to CreateQueryIndexTests which test each operation, it uses stubs for the http requests so we can run against CouchDB 1.6.x.

## Reviewers
reviewer: @brynh

## Issues
Resolves #7 