### PR TITLE
Move to using delegates to enable streaming support

### DIFF
--- a/Source/CouchOperation.swift
+++ b/Source/CouchOperation.swift
@@ -234,6 +234,7 @@ public class CouchOperation: NSOperation, HTTPRequestOperation
     }
 
     final func completeOperation() {
+        self.executor = nil // break the cycle.
         self.isExecuting = false
         self.isFinished = true
     }

--- a/Source/SessionCookieInterceptor.swift
+++ b/Source/SessionCookieInterceptor.swift
@@ -39,9 +39,9 @@ public class SessionCookieInterceptor: HTTPInterceptor
      */
     var cookie: String?
     /**
-     The `InterceptableSession` to use when making HTTP requests.
+     The `NSURLSession` to use when making HTTP requests.
      */
-    let urlSession: InterceptableSession
+    let urlSession: NSURLSession
 
     init(username: String, password: String) {
         let encodedUsername = username.addingPercentEncoding(withAllowedCharacters: NSCharacterSet.alphanumerics())!
@@ -50,8 +50,7 @@ public class SessionCookieInterceptor: HTTPInterceptor
         let payload = "name=\(encodedUsername)&password=\(encodedPassword)"
 
         sessionRequestBody = payload.data(using: NSASCIIStringEncoding)!
-        urlSession = InterceptableSession()
-
+        urlSession = NSURLSession(configuration: NSURLSessionConfiguration.ephemeral())
     }
 
     public func interceptResponse(context: HTTPInterceptorContext) -> HTTPInterceptorContext {
@@ -110,8 +109,8 @@ public class SessionCookieInterceptor: HTTPInterceptor
             return nil
         }
         var cookie: String?
-
-        let task = self.urlSession.dataTask(request: request) { (data, response, error) -> Void in
+ 
+        let task = self.urlSession.dataTask(with: request) { (data, response, error) -> Void in
 
             // defer semaphore
             defer { dispatch_semaphore_signal(semaphore) }


### PR DESCRIPTION
## What
To make it easier to support streaming of data from the server, we need to move
to using delegates so we can dispatch the data back to the requesting operation
as it becomes avaiable. 

## How
URLSessionTask is now just a wrapper for a NSURLSessionDataTask, said task may be swapped out depending on the result of the response interceptor run when the response is reccieved.

In the even the response is reccived from the server and the interceptor run
indicates the request should be retired, the task will be cancelled, and removed
from the taskDict and URLSessionTask, and replaced with a new task which represents
the rerun. Assuming the interceptor run allows for the response to be delivered, the
resposne and data will be deliver to the requesting operation via the InterableSessionDelegate,
this makes it possbile to implement streaming outside of the URLSession class making it possible
to provide the same interface to both streaming and non streaming operations.

## Reviewers

## Issues
This partly allows for background session as per #12 and makes lays the ground work for streaming data to enable #64 and #26 