### PR TITLE
Add ability to read attachments from the database.

### DIFF
--- a/Source/FindDocumentsOperation.swift
+++ b/Source/FindDocumentsOperation.swift
@@ -239,8 +239,6 @@ public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation {
         }
         
         if let sort = self.sort {
-            transform(sortArray: sort)
-            
             jsonObj["sort"] = transform(sortArray: sort) as NSArray
         }
         

--- a/Source/ReadAttachmentOperation.swift
+++ b/Source/ReadAttachmentOperation.swift
@@ -1,0 +1,74 @@
+//
+//  ReadAttachmentOperation.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 02/06/2016.
+//  Copyright © 2016 IBM. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ An Operation to read an attachment from the database
+ 
+ - Requires: All properties defined on this operation to be set.
+ 
+ Example usage:
+ 
+ ```
+ let read = ReadAttachmentOperation()
+ read.docId = docId
+ read.revId = revId
+ read.attachmentName = attachmentName
+ read.databaseName = dbName
+ read.readAttachmentCompletionHandler = {(data, info, error) in 
+    if let error = error {
+        // handle the error
+    } else {
+        // process the successful response
+    }
+ }
+ database.add(operation:read)
+ ```
+ */
+ 
+public class ReadAttachmentOperation: AttachmentOperation {
+    
+    /**
+     Sets a completion handler to run when the operation completes.
+     
+     - parameter data: - The attachment data.
+     - parameter httpInfo: - Information about the HTTP response.
+     - parameter error: - ErrorProtocol instance with information about an error executing the operation.
+     */
+    public var readAttachmentCompletionHandler: ((data:NSData?, httpInfo:HttpInfo?, error: ErrorProtocol?) -> Void)?
+    
+    public override func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+        guard error == nil, let httpInfo = httpInfo
+            else {
+                self.callCompletionHandler(error: error!)
+                return
+        }
+                if httpInfo.statusCode / 100 == 2 {
+                    self.readAttachmentCompletionHandler?(data: data, httpInfo: httpInfo, error: error)
+                } else {
+                    self.readAttachmentCompletionHandler?(data: data, httpInfo: httpInfo, error: Errors.HTTP(statusCode: httpInfo.statusCode, response: String(data: data!, encoding: NSUTF8StringEncoding)))
+                }
+
+    }
+    
+    public override var httpMethod: String {
+        return "GET"
+    }
+    
+    
+    
+}

--- a/SwiftCloudant.xcodeproj/project.pbxproj
+++ b/SwiftCloudant.xcodeproj/project.pbxproj
@@ -10,8 +10,8 @@
 		2C4B910F7FFAC8132F5280BB /* Pods_SwiftCloudantTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F96FB133EC7F68F6BF31CC3 /* Pods_SwiftCloudantTests.framework */; };
 		2E79FE9C1CDA2BF500AD20E2 /* QueryViewOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */; };
 		2E79FE9E1CDA2C0900AD20E2 /* QueryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E79FE9D1CDA2C0900AD20E2 /* QueryViewTests.swift */; };
-		980A04941CEC56B000F5F049 /* DeleteQueryIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */; };
 		980A04901CEB739700F5F049 /* DeleteAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A048F1CEB739700F5F049 /* DeleteAttachmentTests.swift */; };
+		980A04941CEC56B000F5F049 /* DeleteQueryIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */; };
 		9855CF6F1CC6458F00ED28DA /* RequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6B1CC6458F00ED28DA /* RequestBuilder.swift */; };
 		9855CF701CC6458F00ED28DA /* RequestExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6C1CC6458F00ED28DA /* RequestExecutor.swift */; };
 		9855CF711CC6458F00ED28DA /* SessionCookieInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF6D1CC6458F00ED28DA /* SessionCookieInterceptor.swift */; };
@@ -28,6 +28,8 @@
 		9855CF861CC8CE5F00ED28DA /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */; };
 		98593EE41CE373CA008F365F /* PutAttachmentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */; };
 		98593EE61CE378A7008F365F /* PutAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98593EE51CE378A7008F365F /* PutAttachmentTests.swift */; };
+		986DA7231D006E7F0065D462 /* ReadAttachmentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986DA7221D006E7F0065D462 /* ReadAttachmentOperation.swift */; };
+		986DA7251D0072550065D462 /* ReadAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986DA7241D0072550065D462 /* ReadAttachmentTests.swift */; };
 		98734A211C88FDB200E79C5B /* SwiftCloudant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98734A171C88FDB200E79C5B /* SwiftCloudant.framework */; };
 		98734A4F1C8A600600E79C5B /* CouchClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A401C8A600600E79C5B /* CouchClient.swift */; };
 		98734A501C8A600600E79C5B /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98734A411C8A600600E79C5B /* Database.swift */; };
@@ -40,8 +42,8 @@
 		98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B4F2CD1CA759130076C5E4 /* PutDocumentTests.swift */; };
 		98C175ED1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C175EC1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift */; };
 		98D129601CF3095E00CF7219 /* GetAllDatabasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */; };
-		98D129661CF3318800CF7219 /* GetAllDatabasesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D129651CF3318800CF7219 /* GetAllDatabasesOperation.swift */; };
 		98D129641CF32D8E00CF7219 /* AttachmentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D129631CF32D8E00CF7219 /* AttachmentOperation.swift */; };
+		98D129661CF3318800CF7219 /* GetAllDatabasesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D129651CF3318800CF7219 /* GetAllDatabasesOperation.swift */; };
 		98E148CF1CF73E81006FE90E /* DeleteAttachmentOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E148CE1CF73E81006FE90E /* DeleteAttachmentOperation.swift */; };
 		98E5431C1C9CCD0500F02E06 /* InterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */; };
 		98EC4AE81CC1533800704CFE /* DeleteDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EC4AE61CC1531200704CFE /* DeleteDocumentTests.swift */; };
@@ -63,8 +65,8 @@
 		2E79FE9B1CDA2BF500AD20E2 /* QueryViewOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = QueryViewOperation.swift; path = Source/QueryViewOperation.swift; sourceTree = SOURCE_ROOT; };
 		2E79FE9D1CDA2C0900AD20E2 /* QueryViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryViewTests.swift; sourceTree = "<group>"; };
 		7F96FB133EC7F68F6BF31CC3 /* Pods_SwiftCloudantTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftCloudantTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteQueryIndexTests.swift; sourceTree = "<group>"; };
 		980A048F1CEB739700F5F049 /* DeleteAttachmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteAttachmentTests.swift; sourceTree = "<group>"; };
+		980A04931CEC56B000F5F049 /* DeleteQueryIndexTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteQueryIndexTests.swift; sourceTree = "<group>"; };
 		9855CF6B1CC6458F00ED28DA /* RequestBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestBuilder.swift; path = Source/RequestBuilder.swift; sourceTree = SOURCE_ROOT; };
 		9855CF6C1CC6458F00ED28DA /* RequestExecutor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RequestExecutor.swift; path = Source/RequestExecutor.swift; sourceTree = SOURCE_ROOT; };
 		9855CF6D1CC6458F00ED28DA /* SessionCookieInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SessionCookieInterceptor.swift; path = Source/SessionCookieInterceptor.swift; sourceTree = SOURCE_ROOT; };
@@ -81,6 +83,8 @@
 		9855CF851CC8CE5F00ED28DA /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PutAttachmentOperation.swift; path = Source/PutAttachmentOperation.swift; sourceTree = SOURCE_ROOT; };
 		98593EE51CE378A7008F365F /* PutAttachmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PutAttachmentTests.swift; sourceTree = "<group>"; };
+		986DA7221D006E7F0065D462 /* ReadAttachmentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReadAttachmentOperation.swift; path = Source/ReadAttachmentOperation.swift; sourceTree = SOURCE_ROOT; };
+		986DA7241D0072550065D462 /* ReadAttachmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadAttachmentTests.swift; sourceTree = "<group>"; };
 		98734A171C88FDB200E79C5B /* SwiftCloudant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftCloudant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98734A201C88FDB200E79C5B /* SwiftCloudantTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftCloudantTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		98734A401C8A600600E79C5B /* CouchClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouchClient.swift; sourceTree = "<group>"; };
@@ -96,8 +100,8 @@
 		98B4F2CD1CA759130076C5E4 /* PutDocumentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PutDocumentTests.swift; sourceTree = "<group>"; };
 		98C175EC1CEC5DF800A9CF2F /* DeleteQueryIndexOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeleteQueryIndexOperation.swift; path = Source/DeleteQueryIndexOperation.swift; sourceTree = SOURCE_ROOT; };
 		98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetAllDatabasesTests.swift; sourceTree = "<group>"; };
-		98D129651CF3318800CF7219 /* GetAllDatabasesOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GetAllDatabasesOperation.swift; path = Source/GetAllDatabasesOperation.swift; sourceTree = SOURCE_ROOT; };
 		98D129631CF32D8E00CF7219 /* AttachmentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttachmentOperation.swift; path = Source/AttachmentOperation.swift; sourceTree = SOURCE_ROOT; };
+		98D129651CF3318800CF7219 /* GetAllDatabasesOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GetAllDatabasesOperation.swift; path = Source/GetAllDatabasesOperation.swift; sourceTree = SOURCE_ROOT; };
 		98E148CE1CF73E81006FE90E /* DeleteAttachmentOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DeleteAttachmentOperation.swift; path = Source/DeleteAttachmentOperation.swift; sourceTree = SOURCE_ROOT; };
 		98E5431B1C9CCD0500F02E06 /* InterceptorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterceptorTests.swift; sourceTree = "<group>"; };
 		98EC4AE61CC1531200704CFE /* DeleteDocumentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteDocumentTests.swift; sourceTree = "<group>"; };
@@ -187,6 +191,7 @@
 				98593EE31CE373CA008F365F /* PutAttachmentOperation.swift */,
 				988A746C1CECC25A00242C24 /* CreateQueryIndexOperation.swift */,
 				98D129631CF32D8E00CF7219 /* AttachmentOperation.swift */,
+				986DA7221D006E7F0065D462 /* ReadAttachmentOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -210,6 +215,7 @@
 				98D1295F1CF3095E00CF7219 /* GetAllDatabasesTests.swift */,
 				988A746E1CECC26B00242C24 /* CreateQueryIndexTests.swift */,
 				980A048F1CEB739700F5F049 /* DeleteAttachmentTests.swift */,
+				986DA7241D0072550065D462 /* ReadAttachmentTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -402,6 +408,7 @@
 				98593EE41CE373CA008F365F /* PutAttachmentOperation.swift in Sources */,
 				98E148CF1CF73E81006FE90E /* DeleteAttachmentOperation.swift in Sources */,
 				98D129641CF32D8E00CF7219 /* AttachmentOperation.swift in Sources */,
+				986DA7231D006E7F0065D462 /* ReadAttachmentOperation.swift in Sources */,
 				9855CF711CC6458F00ED28DA /* SessionCookieInterceptor.swift in Sources */,
 				2E79FE9C1CDA2BF500AD20E2 /* QueryViewOperation.swift in Sources */,
 				9855CF801CC6459E00ED28DA /* PutDocumentOperation.swift in Sources */,
@@ -421,6 +428,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				988A746F1CECC26B00242C24 /* CreateQueryIndexTests.swift in Sources */,
+				986DA7251D0072550065D462 /* ReadAttachmentTests.swift in Sources */,
 				980A04901CEB739700F5F049 /* DeleteAttachmentTests.swift in Sources */,
 				98B4F2CE1CA759130076C5E4 /* PutDocumentTests.swift in Sources */,
 				98EC4AE81CC1533800704CFE /* DeleteDocumentTests.swift in Sources */,

--- a/Tests/ReadAttachmentTests.swift
+++ b/Tests/ReadAttachmentTests.swift
@@ -1,0 +1,139 @@
+//
+//  ReadAttachmentTests.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 02/06/2016.
+//  Copyright © 2016 IBM. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+class ReadAttachmentTests: XCTestCase {
+    
+    var dbName: String? = nil
+    var client: CouchDBClient? = nil
+    let docId: String = "PutAttachmentTests"
+    var revId: String?
+    
+    let attachment = "This is my awesome essay attachment for my document"
+    let attachmentName = "myAwesomeAttachment"
+    
+    override func setUp() {
+        super.setUp()
+        
+        dbName = generateDBName()
+        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        createDatabase(databaseName: dbName!, client: client!)
+        let createDoc = PutDocumentOperation()
+        createDoc.body = createTestDocuments(count: 1).first
+        createDoc.docId = docId
+        createDoc.completionHandler = {[weak self] (response, info, error) in
+            self?.revId = response?["rev"] as? String
+        }
+        client?[dbName!].add(operation: createDoc)
+        createDoc.waitUntilFinished()
+        
+        
+        let put = PutAttachmentOperation()
+        put.docId = docId
+        put.revId = revId
+        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.attachmentName = attachmentName
+        put.contentType = "text/plain"
+        put.completionHandler = {[weak self] (response, info, error) in
+            self?.revId = response?["rev"] as? String
+        }
+        client?[dbName!].add(operation: put)
+        put.waitUntilFinished()
+    }
+    
+    override func tearDown() {
+        deleteDatabase(databaseName: dbName!, client: client!)
+        
+        super.tearDown()
+    }
+    
+    func testReadAttachment() {
+        let expectation = self.expectation(withDescription: "read attachment")
+        let read = ReadAttachmentOperation()
+        read.docId = docId
+        read.revId = revId
+        read.attachmentName = attachmentName
+        read.readAttachmentCompletionHandler = {[weak self] (data, info, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(info)
+            if let info = info {
+                XCTAssert(info.statusCode / 100 == 2)
+            }
+            
+            XCTAssertNotNil(data)
+            if let data = data {
+                let attxt = NSString(data: data, encoding: NSUTF8StringEncoding)
+                XCTAssertEqual(self?.attachment, attxt)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        client?[dbName!].add(operation: read)
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testReadAttachmentProperties() {
+        let read = ReadAttachmentOperation()
+        read.docId = docId
+        read.revId = revId
+        read.attachmentName = attachmentName
+        read.databaseName = dbName
+        XCTAssert(read.validate())
+        XCTAssertEqual("GET", read.httpMethod)
+        XCTAssertEqual("/\(dbName!)/\(docId)/\(attachmentName)", read.httpPath)
+        XCTAssertEqual([NSURLQueryItem(name: "rev", value: revId)], read.queryItems)
+        XCTAssertNil(read.httpRequestBody)
+    }
+    
+    func testReadAttachmentValidationMissingDocId() {
+        let read = ReadAttachmentOperation()
+        read.revId = revId
+        read.attachmentName = attachmentName
+        read.databaseName = dbName
+        XCTAssertFalse(read.validate())
+    }
+    
+    func testReadAttachmentValidationMissingRevId() {
+        let read = ReadAttachmentOperation()
+        read.docId = docId
+        read.attachmentName = attachmentName
+        read.databaseName = dbName
+        XCTAssertFalse(read.validate())
+    }
+    
+    func testReadAttachmentValidationMissingAttachmentName() {
+        let read = ReadAttachmentOperation()
+        read.docId = docId
+        read.revId = revId
+        read.databaseName = dbName
+        XCTAssertFalse(read.validate())
+    }
+    
+    func testReadAttachmentValidationMissingdbName() {
+        let read = ReadAttachmentOperation()
+        read.docId = docId
+        read.revId = revId
+        read.attachmentName = attachmentName
+        XCTAssertFalse(read.validate())
+    }
+    
+    
+}


### PR DESCRIPTION
## What

Add the ability to read attachments from the database.

## How

Added the `ReadAttachmentOperation`, this has a couple of limitations,
due to the object hierarchy, the ReadAttachmentOperation defines a new completion handler,
readAttachmentCompletionHandler, to receive the data from the database. This does mean the standard
completion handler *will* not be called for ReadAttachmentOperation instances.

## Testing

New tests added, see `ReadAttachmentTests` for details.

## Issues

Resolves #64