### PR TITLE
Correct Access control specifiers

### DIFF
--- a/Source/CreateDatabaseOperation.swift
+++ b/Source/CreateDatabaseOperation.swift
@@ -21,6 +21,8 @@ import Foundation
  */
 public class CreateDatabaseOperation: CouchOperation, JsonOperation {
 
+    public init() { }
+    
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     
     /**

--- a/Source/CreateQueryIndexOperation.swift
+++ b/Source/CreateQueryIndexOperation.swift
@@ -41,6 +41,8 @@ import Foundation
  */
 public class CreateJsonQueryIndexOperation: CouchDatabaseOperation, MangoOperation, JsonOperation {
     
+    public init() { }
+    
     public var databaseName: String?
     
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
@@ -169,6 +171,8 @@ public enum TextIndexFieldType : String {
  client.add(operation: index)
  */
 public class CreateTextQueryIndexOperation: CouchDatabaseOperation, MangoOperation, JsonOperation {
+    
+    public init() { }
     
     public var databaseName: String?
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?

--- a/Source/DeleteAttachmentOperation.swift
+++ b/Source/DeleteAttachmentOperation.swift
@@ -42,6 +42,8 @@ import Foundation
  */
 public class DeleteAttachmentOperation: CouchDatabaseOperation, JsonOperation {
     
+    public init() { }
+    
     public var databaseName: String?
     
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?

--- a/Source/DeleteDatabaseOperation.swift
+++ b/Source/DeleteDatabaseOperation.swift
@@ -21,6 +21,8 @@ import Foundation
  */
 public class DeleteDatabaseOperation: CouchOperation, JsonOperation {
 
+    public init() { }
+    
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     
     /**

--- a/Source/DeleteDocumentOperation.swift
+++ b/Source/DeleteDocumentOperation.swift
@@ -38,7 +38,7 @@ import Foundation
  */
 public class DeleteDocumentOperation: CouchDatabaseOperation, JsonOperation {
 
-    
+    public init() { }
     
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?

--- a/Source/DeleteQueryIndexOperation.swift
+++ b/Source/DeleteQueryIndexOperation.swift
@@ -54,6 +54,8 @@ public enum IndexType : String {
  */
 public class DeleteQueryIndexOperation: CouchDatabaseOperation, JsonOperation {
     
+    public init() { }
+    
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
 

--- a/Source/FindDocumentsOperation.swift
+++ b/Source/FindDocumentsOperation.swift
@@ -107,6 +107,8 @@ internal extension MangoOperation {
  */
 public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation, JsonOperation {
     
+    public init() { }
+    
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
     

--- a/Source/GetAllDatabasesOperation.swift
+++ b/Source/GetAllDatabasesOperation.swift
@@ -36,6 +36,8 @@ import Foundation
  */
 public class GetAllDatabasesOperation : CouchOperation, JsonOperation {
     
+    public init() { }
+    
     /**
         Handler to run for each database returned.
      

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -18,6 +18,8 @@ import Foundation
 
 public class GetDocumentOperation: CouchDatabaseOperation, JsonOperation {
 
+    public init() { }
+    
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     
     public var databaseName: String?

--- a/Source/PutAttachmentOperation.swift
+++ b/Source/PutAttachmentOperation.swift
@@ -45,6 +45,8 @@ import Foundation
  */
 public class PutAttachmentOperation: CouchDatabaseOperation, JsonOperation {
     
+    public init() { }
+    
     public var databaseName: String?
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -18,6 +18,8 @@ import Foundation
 
 public class PutDocumentOperation: CouchDatabaseOperation, JsonOperation {
     
+    public init() { }
+    
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
     /**

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -52,6 +52,8 @@ import Foundation
  */
 public class QueryViewOperation: CouchDatabaseOperation, JsonOperation {
     
+    public init() { }
+    
     public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
 

--- a/Source/ReadAttachmentOperation.swift
+++ b/Source/ReadAttachmentOperation.swift
@@ -42,6 +42,8 @@ import Foundation
  
 public class ReadAttachmentOperation: CouchDatabaseOperation, DataOperation {
     
+    public init() { }
+    
     /**
      Sets a completion handler to run when the operation completes.
      

--- a/Source/RequestExecutor.swift
+++ b/Source/RequestExecutor.swift
@@ -23,11 +23,11 @@ public struct HttpInfo {
     /**
      The status code of the HTTP request.
      */
-    let statusCode: Int
+    public let statusCode: Int
     /**
      The headers that were returned by the server.
      */
-    let headers: [String: String]
+    public let headers: [String: String]
 }
 
 /**


### PR DESCRIPTION
## What

Correct the access control specifiers for init methods and `HttpInfo`

## How

- Create public init methods for operations
- Make properties on HttpInfo public.

## Testing

None, test code isn't effected due to the `@testable` attribute for the imports.
## Issues

#86 
#87 
