### PR TITLE
Rename HttpInfo to HTTPInfo

### DIFF
--- a/Source/CreateDatabaseOperation.swift
+++ b/Source/CreateDatabaseOperation.swift
@@ -23,7 +23,7 @@ public class CreateDatabaseOperation: CouchOperation, JsonOperation {
 
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     /**
      The name of the database to create.

--- a/Source/CreateQueryIndexOperation.swift
+++ b/Source/CreateQueryIndexOperation.swift
@@ -45,7 +45,7 @@ public class CreateJsonQueryIndexOperation: CouchDatabaseOperation, MangoOperati
     
     public var databaseName: String?
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     /**
      The name of the index.
@@ -175,7 +175,7 @@ public class CreateTextQueryIndexOperation: CouchDatabaseOperation, MangoOperati
     public init() { }
     
     public var databaseName: String?
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     /**
      The name of the index

--- a/Source/DeleteAttachmentOperation.swift
+++ b/Source/DeleteAttachmentOperation.swift
@@ -46,7 +46,7 @@ public class DeleteAttachmentOperation: CouchDatabaseOperation, JsonOperation {
     
     public var databaseName: String?
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     /**
      The id of the document that the attachment is attached to.

--- a/Source/DeleteDatabaseOperation.swift
+++ b/Source/DeleteDatabaseOperation.swift
@@ -23,7 +23,7 @@ public class DeleteDatabaseOperation: CouchOperation, JsonOperation {
 
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     /**
      The name of the database to delete.

--- a/Source/DeleteDocumentOperation.swift
+++ b/Source/DeleteDocumentOperation.swift
@@ -40,7 +40,7 @@ public class DeleteDocumentOperation: CouchDatabaseOperation, JsonOperation {
 
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
 
     /**

--- a/Source/DeleteQueryIndexOperation.swift
+++ b/Source/DeleteQueryIndexOperation.swift
@@ -56,7 +56,7 @@ public class DeleteQueryIndexOperation: CouchDatabaseOperation, JsonOperation {
     
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
 
 	/**

--- a/Source/FindDocumentsOperation.swift
+++ b/Source/FindDocumentsOperation.swift
@@ -109,7 +109,7 @@ public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation, Jso
     
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
     
     /**
@@ -299,7 +299,7 @@ public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation, Jso
         }
     }
     
-    public func callCompletionHandler(response: Any?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+    public func callCompletionHandler(response: Any?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
         self.completionHandler?(response: response as? [String: AnyObject], httpInfo: httpInfo, error: error)
     }
 

--- a/Source/GetAllDatabasesOperation.swift
+++ b/Source/GetAllDatabasesOperation.swift
@@ -45,7 +45,7 @@ public class GetAllDatabasesOperation : CouchOperation, JsonOperation {
      */
     public var databaseHandler: ((databaseName: String) -> Void)?
     
-    public var completionHandler: ((response: [AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     public var endpoint: String {
         return "/_all_dbs"

--- a/Source/GetDocumentOperation.swift
+++ b/Source/GetDocumentOperation.swift
@@ -20,7 +20,7 @@ public class GetDocumentOperation: CouchDatabaseOperation, JsonOperation {
 
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     public var databaseName: String?
     

--- a/Source/Operation.swift
+++ b/Source/Operation.swift
@@ -133,7 +133,7 @@ public class Operation: NSOperation, HTTPRequestOperation
 
     internal var executor: OperationRequestExecutor? = nil
 
-    internal func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+    internal func processResponse(data: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
         couchOperation.processResponse(data: data, httpInfo: httpInfo, error: error)
     }
 

--- a/Source/OperationProtocols.swift
+++ b/Source/OperationProtocols.swift
@@ -57,7 +57,7 @@ public protocol CouchOperation {
      - parameter httpInfo: Information about the HTTP response.
      - parameter error: The error that occurred, or nil if the request was made successfully.
     */
-    func callCompletionHandler(response: Any?, httpInfo: HttpInfo?, error: ErrorProtocol?)
+    func callCompletionHandler(response: Any?, httpInfo: HTTPInfo?, error: ErrorProtocol?)
     
     /**
      This method is called from the
@@ -84,7 +84,7 @@ public protocol CouchOperation {
      * processResponse(json:) when a 2xx response code was received and the response is a JSON response.
        This allows an operation to provide additional processing of the JSON.
      */
-    func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?)
+    func processResponse(data: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?)
     
     /**
      Validates the operation has been set up correctly, subclasses should override but call and
@@ -146,16 +146,16 @@ public protocol JsonOperation: CouchOperation {
      - parameter httpInfo: - Information about the HTTP response.
      - parameter error: - ErrorProtocol instance with information about an error executing the operation.
      */
-    var completionHandler: ((response: Json?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)? { get set }
+    var completionHandler: ((response: Json?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)? { get set }
 }
 
 public extension JsonOperation {
     
-    public func callCompletionHandler(response: Any?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+    public func callCompletionHandler(response: Any?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
         self.completionHandler?(response: response as? Json, httpInfo: httpInfo, error: error)
     }
     
-    public func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+    public func processResponse(data: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
         guard error == nil, let httpInfo = httpInfo
             else {
                 self.callCompletionHandler(error: error!)
@@ -202,15 +202,15 @@ public protocol DataOperation: CouchOperation {
      - parameter httpInfo: - Information about the HTTP response.
      - parameter error: - ErrorProtocol instance with information about an error executing the operation.
      */
-    var completionHandler: ((response: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)? { get set }
+    var completionHandler: ((response: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)? { get set }
 }
 
 public extension DataOperation {
-    public func callCompletionHandler(response: Any?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+    public func callCompletionHandler(response: Any?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
         self.completionHandler?(response: response as? NSData, httpInfo: httpInfo, error: error)
     }
     
-    public func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) {
+    public func processResponse(data: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
         guard error == nil, let httpInfo = httpInfo
             else {
                 self.callCompletionHandler(error: error!)

--- a/Source/PutAttachmentOperation.swift
+++ b/Source/PutAttachmentOperation.swift
@@ -48,7 +48,7 @@ public class PutAttachmentOperation: CouchDatabaseOperation, JsonOperation {
     public init() { }
     
     public var databaseName: String?
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     /**
      The id of the document that the attachment should be attached to.

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -20,7 +20,7 @@ public class PutDocumentOperation: CouchDatabaseOperation, JsonOperation {
     
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
     /**
      The document that this operation will modify.
@@ -30,7 +30,7 @@ public class PutDocumentOperation: CouchDatabaseOperation, JsonOperation {
     public var docId: String? = nil
 
     /**
-     If updating a document, set this value to the current revision ID.
+     If updating a document, set this value to the current revision ID.HTTPInfo
      */
     public var revId: String? = nil
 

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -54,7 +54,7 @@ public class QueryViewOperation: CouchDatabaseOperation, JsonOperation {
     
     public init() { }
     
-    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     public var databaseName: String?
 
     /**

--- a/Source/ReadAttachmentOperation.swift
+++ b/Source/ReadAttachmentOperation.swift
@@ -51,7 +51,7 @@ public class ReadAttachmentOperation: CouchDatabaseOperation, DataOperation {
      - parameter httpInfo: - Information about the HTTP response.
      - parameter error: - ErrorProtocol instance with information about an error executing the operation.
      */
-    public var completionHandler: ((response: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     public var databaseName: String?
     

--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -67,7 +67,7 @@ internal protocol HTTPRequestOperation   {
      - parameter httpInfo: Information about the HTTP response.
      - parameter error: A type representing an error if one occurred or `nil`
      */
-    func processResponse(data: NSData?, httpInfo: HttpInfo?, error: ErrorProtocol?);
+    func processResponse(data: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?);
 
     var isCancelled: Bool { get }
 

--- a/Source/RequestExecutor.swift
+++ b/Source/RequestExecutor.swift
@@ -19,7 +19,7 @@ import Foundation
 /**
  Contains HTTP response information.
  */
-public struct HttpInfo {
+public struct HTTPInfo {
     /**
      The status code of the HTTP request.
      */
@@ -78,10 +78,10 @@ class OperationRequestExecutor: InterceptableSessionDelegate {
             return
         }
         
-        let httpInfo: HttpInfo?
+        let httpInfo: HTTPInfo?
         
         if let response = response {
-            httpInfo = HttpInfo(statusCode: response.statusCode, headers: response.allHeaderFields as! [String: String])
+            httpInfo = HTTPInfo(statusCode: response.statusCode, headers: response.allHeaderFields as! [String: String])
         } else {
             httpInfo = nil
         }

--- a/Tests/SwiftCloudant/TestHelpers.swift
+++ b/Tests/SwiftCloudant/TestHelpers.swift
@@ -101,17 +101,17 @@ extension XCTestCase {
     }
     
     func simulateCreatedResponseFor(operation: CouchOperation, jsonResponse: JSONResponse = ["ok": true, "rev": "1-thisisarevision"]) {
-        simulateExecutionOf(operation: operation, httpResponse: HttpInfo(statusCode: 201, headers: [:]), response: jsonResponse)
+        simulateExecutionOf(operation: operation, httpResponse: HTTPInfo(statusCode: 201, headers: [:]), response: jsonResponse)
     }
     
     func simulateOkResponseFor(operation: CouchOperation, jsonResponse: JSONResponse = ["ok" : true]) {
-        simulateExecutionOf(operation: operation, httpResponse: HttpInfo(statusCode: 200, headers: [:]), response: jsonResponse)
+        simulateExecutionOf(operation: operation, httpResponse: HTTPInfo(statusCode: 200, headers: [:]), response: jsonResponse)
     }
     
-    func simulateExecutionOf(operation: CouchOperation, httpResponse: HttpInfo, response: JSONResponse) {
+    func simulateExecutionOf(operation: CouchOperation, httpResponse: HTTPInfo, response: JSONResponse) {
         do {
             let data = try NSJSONSerialization.data(withJSONObject: response.json)
-            let httpInfo = HttpInfo(statusCode: 200, headers: [:])
+            let httpInfo = HTTPInfo(statusCode: 200, headers: [:])
             self.simulateExecutionOf(operation: operation, httpResponse: httpInfo, response: data)
         } catch {
             NSLog("Failed to seralise json, aborting simulation")
@@ -119,7 +119,7 @@ extension XCTestCase {
 
     }
     
-    func simulateExecutionOf(operation: CouchOperation, httpResponse: HttpInfo, response: NSData) {
+    func simulateExecutionOf(operation: CouchOperation, httpResponse: HTTPInfo, response: NSData) {
         dispatch_async(dispatch_get_main_queue()) {
             
             do {


### PR DESCRIPTION
## What

Rename `HttpInfo` to `HTTPInfo`

## How
Rename `HttpInfo` to `HTTPInfo`

## Why 
Making the `HTTP` upper case in `HTTPInfo` makes it more in keeping with the swift API guidelines  


## Issues

#73 
