### PR TITLE
Support for the 2016-06-30 Swift 3 Snapshot

### DIFF
--- a/Source/CouchClient.swift
+++ b/Source/CouchClient.swift
@@ -23,9 +23,9 @@ public class CouchDBClient {
 
     private let username: String?
     private let password: String?
-    private let rootURL: NSURL
+    private let rootURL: URL
     private let session: InterceptableSession
-    private let queue: NSOperationQueue
+    private let queue: OperationQueue
 
     /**
      Creates a CouchDBClient instance.
@@ -34,11 +34,11 @@ public class CouchDBClient {
      - parameter username: the username to use when authenticating.
      - parameter password: the password to use when authenticating.
      */
-    public init(url: NSURL, username: String?, password: String?) {
+    public init(url: URL, username: String?, password: String?) {
         self.rootURL = url
         self.username = username
         self.password = password
-        queue = NSOperationQueue()
+        queue = OperationQueue()
         let interceptors: [HTTPInterceptor]
 
         if let username = username, let password = password {

--- a/Source/CreateQueryIndexOperation.swift
+++ b/Source/CreateQueryIndexOperation.swift
@@ -69,14 +69,14 @@ public class CreateJsonQueryIndexOperation: CouchDatabaseOperation, MangoOperati
      */
     public var designDoc: String?
 
-    private var jsonData: NSData?
+    private var jsonData: Data?
     
     
     public var method: String {
         return "POST"
     }
 
-    public var data: NSData? {
+    public var data: Data? {
         return self.jsonData
     }
     
@@ -131,7 +131,7 @@ public class CreateJsonQueryIndexOperation: CouchDatabaseOperation, MangoOperati
         #if os(Linux)
             jsonData = try NSJSONSerialization.data(withJSONObject:jsonDict.bridge())
         #else
-            jsonData = try NSJSONSerialization.data(withJSONObject:jsonDict as NSDictionary)
+            jsonData = try JSONSerialization.data(withJSONObject:jsonDict as NSDictionary)
         #endif
     }
     
@@ -249,8 +249,8 @@ public class CreateTextQueryIndexOperation: CouchDatabaseOperation, MangoOperati
      */
     public var designDoc: String?
 
-    private var jsonData : NSData?
-    public  var data: NSData? {
+    private var jsonData : Data?
+    public  var data: Data? {
         return jsonData
     }
     
@@ -271,7 +271,7 @@ public class CreateTextQueryIndexOperation: CouchDatabaseOperation, MangoOperati
             #if os(Linux)
                 return NSJSONSerialization.isValidJSONObject(selector.bridge())
             #else
-                return NSJSONSerialization.isValidJSONObject(selector as NSDictionary)
+                return JSONSerialization.isValidJSONObject(selector as NSDictionary)
             #endif
         }
         
@@ -356,7 +356,7 @@ public class CreateTextQueryIndexOperation: CouchDatabaseOperation, MangoOperati
                     jsonDict["index"] = index as NSDictionary
                 }
                 
-                self.jsonData = try NSJSONSerialization.data(withJSONObject:jsonDict as NSDictionary)
+                self.jsonData = try JSONSerialization.data(withJSONObject:jsonDict as NSDictionary)
             #endif
             
 

--- a/Source/FindDocumentsOperation.swift
+++ b/Source/FindDocumentsOperation.swift
@@ -214,8 +214,8 @@ public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation, Jso
         return "/\(self.databaseName!)/_find"
     }
 
-    private var jsonData: NSData?
-    public var data: NSData? {
+    private var jsonData: Data?
+    public var data: Data? {
         return self.jsonData
     }
 
@@ -237,7 +237,7 @@ public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation, Jso
                 return false
             }
         #else
-            if NSJSONSerialization.isValidJSONObject(jsonObj as NSDictionary) {
+            if JSONSerialization.isValidJSONObject(jsonObj as NSDictionary) {
                 self.json = jsonObj
                 return true
             } else {
@@ -352,7 +352,7 @@ public class FindDocumentsOperation: CouchDatabaseOperation, MangoOperation, Jso
             #if os(Linux)
                 self.jsonData = try NSJSONSerialization.data(withJSONObject: json.bridge())
             #else
-                self.jsonData = try NSJSONSerialization.data(withJSONObject: json as NSDictionary)
+                self.jsonData = try JSONSerialization.data(withJSONObject: json as NSDictionary)
             #endif
         }
     }

--- a/Source/Operation.swift
+++ b/Source/Operation.swift
@@ -40,7 +40,7 @@ enum Errors: ErrorProtocol {
 /**
  An NSOperation subclass for executing `CouchOperations`
  */
-public class Operation: NSOperation, HTTPRequestOperation
+public class Operation: Foundation.Operation, HTTPRequestOperation
 {
     
     private let couchOperation: CouchOperation
@@ -102,7 +102,7 @@ public class Operation: NSOperation, HTTPRequestOperation
         }
     }
 
-    internal var rootURL: NSURL = NSURL(string: "http://cloudant.invalid")!
+    internal var rootURL: URL = URL(string: "http://cloudant.invalid")!
 
     internal var httpPath: String {
         return couchOperation.endpoint
@@ -111,12 +111,12 @@ public class Operation: NSOperation, HTTPRequestOperation
         return couchOperation.method
     }
 
-    internal var queryItems: [NSURLQueryItem] {
+    internal var queryItems: [URLQueryItem] {
         get {
-            var items:[NSURLQueryItem] = []
+            var items:[URLQueryItem] = []
             
             for (key, value) in couchOperation.parameters {
-                items.append(NSURLQueryItem(name: key, value: value))
+                items.append(URLQueryItem(name: key, value: value))
             }
             return items
         }
@@ -127,13 +127,13 @@ public class Operation: NSOperation, HTTPRequestOperation
     }
 
     // return nil if there is no body
-    internal var httpRequestBody: NSData? {
+    internal var httpRequestBody: Data? {
         return couchOperation.data
     }
 
     internal var executor: OperationRequestExecutor? = nil
 
-    internal func processResponse(data: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
+    internal func processResponse(data: Data?, httpInfo: HTTPInfo?, error: ErrorProtocol?) {
         couchOperation.processResponse(data: data, httpInfo: httpInfo, error: error)
     }
 

--- a/Source/PutAttachmentOperation.swift
+++ b/Source/PutAttachmentOperation.swift
@@ -69,7 +69,7 @@ public class PutAttachmentOperation: CouchDatabaseOperation, JsonOperation {
     /**
      The attachment's data.
     */
-    public var data: NSData?
+    public var data: Data?
     
     /**
      The Content type for the attachment such as text/plain, image/jpeg
@@ -117,7 +117,7 @@ public class PutAttachmentOperation: CouchDatabaseOperation, JsonOperation {
         return ["rev": revId!]
     }
     
-    public var httpRequestBody: NSData? {
+    public var httpRequestBody: Data? {
         return data
     }
     

--- a/Source/PutDocumentOperation.swift
+++ b/Source/PutDocumentOperation.swift
@@ -41,7 +41,7 @@ public class PutDocumentOperation: CouchDatabaseOperation, JsonOperation {
         #if os(Linux)
             return databaseName != nil && docId != nil && body != nil && NSJSONSerialization.isValidJSONObject(body!.bridge())
         #else
-            return databaseName != nil && docId != nil && body != nil && NSJSONSerialization.isValidJSONObject(body! as NSDictionary)
+            return databaseName != nil && docId != nil && body != nil && JSONSerialization.isValidJSONObject(body! as NSDictionary)
         #endif
     }
 
@@ -49,13 +49,13 @@ public class PutDocumentOperation: CouchDatabaseOperation, JsonOperation {
         return "PUT"
     }
 
-    public var data: NSData? {
+    public var data: Data? {
         get {
             do {
                 #if os(Linux)
                     let data = try NSJSONSerialization.data(withJSONObject: body!.bridge(), options: NSJSONWritingOptions())
                 #else
-                    let data = try NSJSONSerialization.data(withJSONObject: body! as NSDictionary, options: NSJSONWritingOptions())
+                    let data = try JSONSerialization.data(withJSONObject: body! as NSDictionary, options: JSONSerialization.WritingOptions())
                 #endif
                 return data
             } catch {

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -254,7 +254,7 @@ public class QueryViewOperation: CouchDatabaseOperation, JsonOperation {
         }
     }
 
-    public var data: NSData? {
+    public var data: Data? {
         if let keys = keys {
             do {
                 #if os(Linux)
@@ -262,7 +262,7 @@ public class QueryViewOperation: CouchDatabaseOperation, JsonOperation {
                 #else
                     let keysDict: NSDictionary = ["keys": keys as NSArray]
                 #endif
-                let keysJson = try NSJSONSerialization.data(withJSONObject: keysDict)
+                let keysJson = try JSONSerialization.data(withJSONObject: keysDict)
                 return keysJson
             } catch {
                 callCompletionHandler(error: error)
@@ -367,9 +367,9 @@ public class QueryViewOperation: CouchDatabaseOperation, JsonOperation {
     }
 
     func convertJson(key: AnyObject) throws -> String {
-        if NSJSONSerialization.isValidJSONObject(key) {
-            let keyJson = try NSJSONSerialization.data(withJSONObject: key)
-            return String(data: keyJson, encoding: NSUTF8StringEncoding)!
+        if JSONSerialization.isValidJSONObject(key) {
+            let keyJson = try JSONSerialization.data(withJSONObject: key)
+            return String(data: keyJson, encoding: .utf8)!
         } else if key is String {
             // we need to quote JSON primitive strings
             return "\"\(key)\""

--- a/Source/ReadAttachmentOperation.swift
+++ b/Source/ReadAttachmentOperation.swift
@@ -51,7 +51,7 @@ public class ReadAttachmentOperation: CouchDatabaseOperation, DataOperation {
      - parameter httpInfo: - Information about the HTTP response.
      - parameter error: - ErrorProtocol instance with information about an error executing the operation.
      */
-    public var completionHandler: ((response: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
+    public var completionHandler: ((response: Data?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
     
     public var databaseName: String?
     

--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -25,7 +25,7 @@ internal protocol HTTPRequestOperation   {
     /**
      The root of url, e.g. `example.cloudant.com`
      */
-    var rootURL: NSURL { get }
+    var rootURL: URL { get }
     
     /**
      The path of the url e.g. `/exampledb/document1/`
@@ -38,12 +38,12 @@ internal protocol HTTPRequestOperation   {
     /**
      The query items to use for the request
      */
-    var queryItems: [NSURLQueryItem] { get }
+    var queryItems: [URLQueryItem] { get }
     
     /**
      The body of the HTTP request or `nil` if there is no data for the request.
      */
-    var httpRequestBody: NSData? { get }
+    var httpRequestBody: Data? { get }
     
     /**
      The content type of the HTTP request payload. This is guranteed to be called
@@ -67,7 +67,7 @@ internal protocol HTTPRequestOperation   {
      - parameter httpInfo: Information about the HTTP response.
      - parameter error: A type representing an error if one occurred or `nil`
      */
-    func processResponse(data: NSData?, httpInfo: HTTPInfo?, error: ErrorProtocol?);
+    func processResponse(data: Data?, httpInfo: HTTPInfo?, error: ErrorProtocol?);
 
     var isCancelled: Bool { get }
 
@@ -99,13 +99,14 @@ class OperationRequestBuilder {
     /**
      Builds the NSURLRequest from the operation in the property `operation`
      */
-    func buildRequest() throws -> NSURLRequest {
+    func buildRequest() throws -> URLRequest {
+        
         guard let components = NSURLComponents(url: operation.rootURL, resolvingAgainstBaseURL: false)
         else {
             throw Error.URLGenerationFailed
         }
         components.path = operation.httpPath
-        var queryItems: [NSURLQueryItem] = []
+        var queryItems: [URLQueryItem] = []
 
         if let _ = components.queryItems {
             queryItems.append(contentsOf: components.queryItems!)
@@ -119,7 +120,7 @@ class OperationRequestBuilder {
             throw Error.URLGenerationFailed
         }
 
-        let request = NSMutableURLRequest(url: url)
+        var request = URLRequest(url: url)
         request.cachePolicy = .useProtocolCachePolicy
         request.timeoutInterval = 10.0
         request.httpMethod = operation.httpMethod

--- a/Source/RequestExecutor.swift
+++ b/Source/RequestExecutor.swift
@@ -44,8 +44,8 @@ class OperationRequestExecutor: InterceptableSessionDelegate {
      */
     let operation: HTTPRequestOperation
     
-    let buffer: NSMutableData
-    var response: NSHTTPURLResponse?
+    var buffer: Data
+    var response: HTTPURLResponse?
     /**
      Creates an OperationRequestExecutor.
      - parameter operation: The operation that this OperationRequestExecutor will execute
@@ -53,10 +53,10 @@ class OperationRequestExecutor: InterceptableSessionDelegate {
     init(operation: HTTPRequestOperation) {
         self.operation = operation
         task = nil
-        buffer = NSMutableData()
+        buffer = Data()
     }
     
-    func received(data: NSData) {
+    func received(data: Data) {
         // This class doesn't support streaming of data
         // so we buffer until the request completes 
         // and then we will deliver it to the
@@ -64,7 +64,7 @@ class OperationRequestExecutor: InterceptableSessionDelegate {
         buffer.append(data)
     }
     
-    func received(response: NSHTTPURLResponse) {
+    func received(response: HTTPURLResponse) {
         // Store the response to deliver with the data when the task completes.
         self.response = response
     }

--- a/Tests/SwiftCloudant/CreateDatabaseTests.swift
+++ b/Tests/SwiftCloudant/CreateDatabaseTests.swift
@@ -26,7 +26,7 @@ class CreateDatabaseTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
     }
 
     override func tearDown() {

--- a/Tests/SwiftCloudant/CreateQueryIndexTests.swift
+++ b/Tests/SwiftCloudant/CreateQueryIndexTests.swift
@@ -29,7 +29,7 @@ public class CreateQueryIndexTests : XCTestCase {
         super.setUp()
         
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string:self.url)!, username: self.username, password: self.password)
+        client = CouchDBClient(url: URL(string:self.url)!, username: self.username, password: self.password)
     }
     
     
@@ -85,7 +85,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"json", "index":["fields" : ["foo"]], "name" : "indexName", "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
         }
         
@@ -111,7 +111,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"text", "index" : [ "selector": ["bar" : "foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]], "name" : "indexName", "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -134,7 +134,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"json", "index":["fields" : ["foo"]], "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -150,7 +150,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"json", "index":["fields" : ["foo"]], "name":"indexName"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -170,7 +170,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"text", "index" : ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]], "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -190,7 +190,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"text", "name": "indexName", "index" : ["selector":["bar":"foo"], "default_field": ["enabled": true, "analyzer": "english" ]], "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -210,7 +210,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"text", "index" : ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]], "name":"indexName"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -230,7 +230,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"text", "index" : ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true ]], "ddoc":"ddoc", "name": "indexName"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -250,7 +250,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"text", "index" : [ "selector":["bar":"foo"],"fields" : [["foo":"string"]], "default_field": ["analyzer": "english" ]], "ddoc":"ddoc", "name": "indexName"] as NSDictionary, json as? NSDictionary)
         }
     }
@@ -270,7 +270,7 @@ public class CreateQueryIndexTests : XCTestCase {
         
         XCTAssertNotNil(data)
         if let data = data {
-            let json = try NSJSONSerialization.jsonObject(with: data)
+            let json = try JSONSerialization.jsonObject(with: data)
             XCTAssertEqual(["type":"text", "index" : [ "fields" : [["foo":"string"]], "default_field": ["enabled": true, "analyzer": "english" ]],"name":"indexName", "ddoc":"ddoc"] as NSDictionary, json as? NSDictionary)
         }
     }

--- a/Tests/SwiftCloudant/DeleteAttachmentTests.swift
+++ b/Tests/SwiftCloudant/DeleteAttachmentTests.swift
@@ -29,7 +29,7 @@ class DeleteAttachmentTests : XCTestCase {
         super.setUp()
         
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
         createDatabase(databaseName: dbName!, client: client!)
         let createDoc = PutDocumentOperation()
         createDoc.body = createTestDocuments(count: 1).first
@@ -46,7 +46,7 @@ class DeleteAttachmentTests : XCTestCase {
         let put = PutAttachmentOperation()
         put.docId = docId
         put.revId = revId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.data = attachment.data(using: String.Encoding.utf8, allowLossyConversion: false)
         put.attachmentName = "myAwesomeAttachment"
         put.contentType = "text/plain"
         put.databaseName = dbName

--- a/Tests/SwiftCloudant/DeleteDocumentTests.swift
+++ b/Tests/SwiftCloudant/DeleteDocumentTests.swift
@@ -26,7 +26,7 @@ class DeleteDocumentTests: XCTestCase {
         super.setUp()
 
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
         createDatabase(databaseName: dbName!, client: client!)
 
         print("Created database: \(dbName!)")

--- a/Tests/SwiftCloudant/DeleteQueryIndexTests.swift
+++ b/Tests/SwiftCloudant/DeleteQueryIndexTests.swift
@@ -26,7 +26,7 @@ public class DeleteQueryIndexTests: XCTestCase {
     override public func setUp() {
         super.setUp()
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string:self.url)!, username: self.username, password: self.password)
+        client = CouchDBClient(url: URL(string:self.url)!, username: self.username, password: self.password)
     }
 
     override public func tearDown() {

--- a/Tests/SwiftCloudant/FindDocumentOperationTests.swift
+++ b/Tests/SwiftCloudant/FindDocumentOperationTests.swift
@@ -39,7 +39,7 @@ class FindDocumentOperationTests: XCTestCase {
     override func setUp() {
         super.setUp()
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string:self.url)!, username: self.username, password: self.password)
+        client = CouchDBClient(url: URL(string:self.url)!, username: self.username, password: self.password)
     }
     
     override func tearDown() {
@@ -155,7 +155,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
         
             do {
-                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
                 
                 let expected:[String:NSObject] = ["selector":["foo":"bar"],
                                 "fields":["foo","bar"],
@@ -196,7 +196,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
             
             do {
-                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
                 
                 let expected:[String:NSObject] = ["selector":["foo":"bar"],
                                                   "sort": [["foo":"asc"]],
@@ -231,7 +231,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
             
             do {
-                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
                 
                 let expected:[String:NSObject] = ["selector":["foo":"bar"],
                                                   "sort": [["foo":"desc"]],
@@ -292,7 +292,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
             
             do {
-                let json = try NSJSONSerialization.jsonObject(with: httpBody, options: NSJSONReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
                 
                 let expected:[String:NSObject] = ["selector":["foo":"bar"]]
                 

--- a/Tests/SwiftCloudant/GetAllDatabasesTests.swift
+++ b/Tests/SwiftCloudant/GetAllDatabasesTests.swift
@@ -28,7 +28,7 @@ public class GetAllDatabasesTest : XCTestCase {
     override public func setUp() {
         super.setUp()
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
         createDatabase(databaseName: dbName!, client: client!)
     }
     

--- a/Tests/SwiftCloudant/GetDocumentTests.swift
+++ b/Tests/SwiftCloudant/GetDocumentTests.swift
@@ -27,7 +27,7 @@ class GetDocumentTests: XCTestCase {
         super.setUp()
 
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
         createDatabase(databaseName: dbName!, client: client!)
     }
 
@@ -43,12 +43,12 @@ class GetDocumentTests: XCTestCase {
         let data = createTestDocuments(count: 1)
 
         let putDocumentExpectation = expectation(withDescription: "put document")
-        let client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        let client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
 
         let put = PutDocumentOperation()
         put.databaseName = dbName
         put.body = data[0]
-        put.docId = NSUUID().uuidString.lowercased()
+        put.docId = UUID().uuidString.lowercased()
 
         put.completionHandler = { (response, httpInfo, error) in
             putDocumentExpectation.fulfill()
@@ -71,7 +71,7 @@ class GetDocumentTests: XCTestCase {
         let putDocumentExpectation = self.expectation(withDescription: "put document")
         let put = PutDocumentOperation()
         put.body = data[0]
-        put.docId = NSUUID().uuidString.lowercased()
+        put.docId = UUID().uuidString.lowercased()
         put.databaseName = self.dbName
         put.completionHandler = { (response, httpInfo, operationError) in
             putDocumentExpectation.fulfill()
@@ -106,13 +106,13 @@ class GetDocumentTests: XCTestCase {
     func testGetDocumentUsingDBAdd() {
         let data = createTestDocuments(count: 1)
         let getDocumentExpectation = expectation(withDescription: "get document")
-        let client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        let client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
 
         let putDocumentExpectation = self.expectation(withDescription: "put document")
         let put = PutDocumentOperation()
         put.databaseName = dbName
         put.body = data[0]
-        put.docId = NSUUID().uuidString.lowercased()
+        put.docId = UUID().uuidString.lowercased()
         put.completionHandler = { (response, httpInfo, operationError) in
             putDocumentExpectation.fulfill()
             XCTAssertEqual(put.docId, response?["id"] as? String);

--- a/Tests/SwiftCloudant/PutAttachmentTests.swift
+++ b/Tests/SwiftCloudant/PutAttachmentTests.swift
@@ -29,7 +29,7 @@ class PutAttachmentTests : XCTestCase {
         super.setUp()
         
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
         createDatabase(databaseName: dbName!, client: client!)
         let createDoc = PutDocumentOperation()
         createDoc.databaseName = dbName
@@ -172,7 +172,7 @@ class PutAttachmentTests : XCTestCase {
         put.databaseName = dbName
         put.docId = docId
         put.revId = revId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.data = attachment.data(using: String.Encoding.utf8, allowLossyConversion: false)
         put.attachmentName = "myAwesomeAttachment"
         put.contentType = "text/plain"
         return put

--- a/Tests/SwiftCloudant/PutDocumentTests.swift
+++ b/Tests/SwiftCloudant/PutDocumentTests.swift
@@ -26,7 +26,7 @@ class PutDocumentTests: XCTestCase {
         super.setUp()
 
         dbName = generateDBName()
-        self.client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        self.client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
         createDatabase(databaseName: dbName!, client: client!)
     }
 

--- a/Tests/SwiftCloudant/QueryViewTests.swift
+++ b/Tests/SwiftCloudant/QueryViewTests.swift
@@ -43,7 +43,7 @@ public class QueryViewTests: XCTestCase {
     override public func setUp() {
         super.setUp()
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
     }
 
     override public func tearDown() {
@@ -164,7 +164,7 @@ public class QueryViewTests: XCTestCase {
         XCTAssertEqual("POST", view.method)
         XCTAssertNotNil(view.data)
         XCTAssertEqual("{\"keys\":[\"testkey\",[\"testkey2\",\"testkey3\"]]}",
-            String(data: view.data!, encoding: NSUTF8StringEncoding))
+            String(data: view.data!, encoding: String.Encoding.utf8))
         XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1", view.endpoint)
 
         let expectedQueryItems = ["descending": "true",

--- a/Tests/SwiftCloudant/ReadAttachmentTests.swift
+++ b/Tests/SwiftCloudant/ReadAttachmentTests.swift
@@ -33,7 +33,7 @@ class ReadAttachmentTests: XCTestCase {
         super.setUp()
         
         dbName = generateDBName()
-        client = CouchDBClient(url: NSURL(string: url)!, username: username, password: password)
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
         createDatabase(databaseName: dbName!, client: client!)
         let createDoc = PutDocumentOperation()
         createDoc.body = createTestDocuments(count: 1).first
@@ -48,7 +48,7 @@ class ReadAttachmentTests: XCTestCase {
         let put = PutAttachmentOperation()
         put.docId = docId
         put.revId = revId
-        put.data = attachment.data(using: NSUTF8StringEncoding, allowLossyConversion: false)
+        put.data = attachment.data(using: String.Encoding.utf8, allowLossyConversion: false)
         put.attachmentName = attachmentName
         put.contentType = "text/plain"
         put.completionHandler = {[weak self] (response, info, error) in
@@ -79,7 +79,7 @@ class ReadAttachmentTests: XCTestCase {
             
             XCTAssertNotNil(data)
             if let data = data {
-                let attxt = NSString(data: data, encoding: NSUTF8StringEncoding)
+                let attxt = String(data: data, encoding: .utf8)
                 XCTAssertEqual(self?.attachment, attxt)
             }
             

--- a/Tests/SwiftCloudant/TestHelpers.swift
+++ b/Tests/SwiftCloudant/TestHelpers.swift
@@ -110,7 +110,7 @@ extension XCTestCase {
     
     func simulateExecutionOf(operation: CouchOperation, httpResponse: HTTPInfo, response: JSONResponse) {
         do {
-            let data = try NSJSONSerialization.data(withJSONObject: response.json)
+            let data = try JSONSerialization.data(withJSONObject: response.json)
             let httpInfo = HTTPInfo(statusCode: 200, headers: [:])
             self.simulateExecutionOf(operation: operation, httpResponse: httpInfo, response: data)
         } catch {
@@ -119,8 +119,8 @@ extension XCTestCase {
 
     }
     
-    func simulateExecutionOf(operation: CouchOperation, httpResponse: HTTPInfo, response: NSData) {
-        dispatch_async(dispatch_get_main_queue()) {
+    func simulateExecutionOf(operation: CouchOperation, httpResponse: HTTPInfo, response: Data) {
+        DispatchQueue.main.async {
             
             do {
                 if !operation.validate() {
@@ -211,7 +211,7 @@ class TestSettings {
     private static var instance: TestSettings?
 
     private init() {
-        let bundle = NSBundle(for: TestSettings.self)
+        let bundle = Bundle(for: TestSettings.self)
 
         let testSettingsPath = bundle.pathForResource("TestSettings", ofType: "plist")
 


### PR DESCRIPTION
## What

Support for the 2016-06-30 Swift 3 Snapshot

## How

- Remove NS Prefixes from some classes, converting them to value types.
- Use modern Dispatch
   - This changes means we need to wait forever for the cookie task to complete before continuing.

## Testing

Tests also updated, they currently all pass

## Issues

Fixes #83 
Fixes #82 
