### PR TITLE
Correct access level for `Sort` struct members

### DIFF
--- a/Source/FindDocumentsOperation.swift
+++ b/Source/FindDocumentsOperation.swift
@@ -38,8 +38,12 @@ public struct Sort {
     /**
      The field on which to sort
      */
-    let field: String
-    let sort: SortDirection?
+    public let field: String
+    
+    /**
+     The direction in which to sort.
+     */
+    public let sort: SortDirection?
 }
 
 /**


### PR DESCRIPTION
## What

Correct access level for `Sort` struct members, it should be directly defined as `public` rather than have
no access modifier.

## Issues

Fixes #98