### PR TITLE
Create AllDocs operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- [NEW] New `GetAllDocs` API.
+- [BREAKING] `skip` and `limit` properties on `QueryViewOperation` are now `UInt`
+
 # 0.3.2 (2016-07-08)
 
 - [FIXED] Created explicit `Sort` and `TextIndexField` initalizers so they are exposed as public.

--- a/Source/GetAllDocsOperation.swift
+++ b/Source/GetAllDocsOperation.swift
@@ -1,0 +1,145 @@
+//
+//  GetAllDocsOperation.swift
+//  SwiftCloudant
+//
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ An Operation to get all the documents in a database.
+ 
+ Example usage:
+ ```
+ let allDocs = GetAllDocsOperation()
+ allDocs.databaseName = "exampleDB"
+ allDocs.docHandler = { doc in 
+    print("Got document: \(doc)")
+ }
+ allDocs.completionHandler = { response, info, error in 
+    if let error = error {
+        // handle error
+    } else {
+        // handle successful response
+    }
+ }
+ client.add(operation: allDocs)
+ ```
+ */
+public class GetAllDocsOperation : CouchOperation, ViewOperation, JsonOperation {
+    
+    public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
+    
+    public var rowHandler: ((row: [String: AnyObject]) -> Void)?
+    
+    public var databaseName: String?
+    
+    public var descending: Bool?
+    
+    public var endKey: String?
+    
+    public var includeDocs: Bool?
+    
+    public var conflicts: Bool?
+
+    public var inclusiveEnd: Bool?
+
+    public var key: String?
+    
+    public var keys: [String]?
+    
+    public var limit: UInt?
+    
+    public var skip: UInt?
+    
+    public var startKeyDocId: String?
+    
+    public var endKeyDocId: String?
+    
+    public var stale: Stale?
+    
+    public var startKey: String?
+    
+    public var updateSeq: Bool?
+    
+    public init(){}
+    
+    private var jsonData: Data?
+    
+    
+    public func validate() -> Bool {
+        if databaseName == nil {
+            return false
+        }
+        
+        if conflicts != nil && includeDocs != true {
+            return false
+        }
+        
+        if keys != nil && key != nil {
+            return false
+        }
+        
+        return true
+    }
+    
+    public var endpoint: String {
+        return "/\(databaseName!)/_all_docs"
+    }
+    
+    public var parameters: [String : String] {
+        get {
+            var params:[String: String] = generateParams()
+            
+            if let endKeyJson = endKeyJson {
+                params["endkey"] = endKeyJson
+            }
+            
+            if let keyJson = keyJson {
+                params["key"] = keyJson
+            }
+            
+            if let startKeyJson = startKeyJson {
+                params["startkey"] = startKeyJson
+            }
+            
+            return params;
+        }
+    }
+    
+    private var keyJson: String?
+    private var endKeyJson: String?
+    private var startKeyJson: String?
+    
+    public func serialise() throws {
+        if let keys = keys {
+            jsonData = try JSONSerialization.data(withJSONObject: keys)
+        }
+        
+        if let key = key {
+            keyJson = try convertJson(key: key)
+        }
+        if let endKey = endKey {
+            endKeyJson = try convertJson(key: endKey)
+        }
+        
+        if let startKey = startKey {
+            startKeyJson = try convertJson(key: startKey)
+        }
+    }
+    
+    public var data: Data? {
+        return jsonData
+    }
+    
+}
+

--- a/Source/ViewLikeOperation.swift
+++ b/Source/ViewLikeOperation.swift
@@ -1,0 +1,265 @@
+//
+//  ViewLikeOperation.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 06/07/2016.
+//
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+
+// This Can't be defined in the extension or the protocol defining outside for now.
+/**
+ Acceptable values for allowing stale views with the `stale` property. To disallow stale views use the default `stale=nil`.
+ */
+public enum Stale: CustomStringConvertible {
+    /// Allow stale views.
+    case Ok
+    /// Allow stale views, but update them immediately after the request.
+    case UpdateAfter
+    
+    public var description: String {
+        switch self {
+        case .Ok: return "ok"
+        case .UpdateAfter: return "update_after"
+        }
+    }
+}
+
+/**
+ Denotes an operation that performs actions on a view.
+ Some operations are not strictly a view externally, but internally
+ they are effectively a view and have similar parameters.
+ */
+public protocol ViewOperation : CouchDatabaseOperation {
+    associatedtype ViewParameter
+    
+    /**
+     Return the result rows in 'descending by key' order.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    var descending: Bool? { get set }
+    
+    /**
+     Return key/value result rows starting from the specified key.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    var startKey: ViewParameter? { get set }
+    
+    /**
+     Used in conjunction with startKey to further restrict the starting row for
+     cases where two documents emit the same key. Specifying the doc ID allows
+     the view to return result rows from the specified start key and document.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+     */
+    var startKeyDocId: String? { get set }
+    
+    /**
+     Stop the view returning result rows when the specified key is reached.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     */
+    var endKey: ViewParameter? { get set }
+    
+    /**
+     Used in conjunction with endKey to further restrict the ending row for cases
+     where two documents emit the same key. Specifying the doc ID allows the view
+     to return result rows up to the specified end key and document.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     */
+    var endKeyDocId: String? { get set }
+    
+    /**
+     Include result rows with the specified `endKey`.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     */
+    var inclusiveEnd: Bool? { get set }
+    
+    /**
+     Return only result rows that match the specified key.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     
+     - Warning: Cannot be used with `keys` option.
+     */
+    var key: ViewParameter? { get set }
+    
+    /**
+     Return only result rows that match the specified keys.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     
+     - Warning: Cannot be used with `key` option.
+     */
+    var keys: [ViewParameter]? { get set }
+    
+    /**
+     Limit the number of result rows returned from the view.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     */
+    var limit: UInt? { get set }
+    
+    /**
+     The number of rows to skip in the view results.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     */
+    var skip: UInt? { get set }
+    
+    /**
+     Include the full content of documents in the view results.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     */
+    var includeDocs: Bool? { get set }
+    
+    /**
+     Include informaion about conflicted revisions in the response.
+     
+     - Note: this can only be used if `includeDocs` is set to `true`.
+     */
+    var conflicts: Bool? { get set }
+    
+    /**
+     Configures the view request to allow the return of stale results. This allows the view to return
+     immediately rather than waiting for the view index to build. When this parameter is omitted (i.e. with the 
+     default of `stale=nil`) the server will not return stale results.
+     
+     - Note: Optional, if the property is unset this parameter will be omitted from the request and the server 
+     default will apply.
+     - SeeAlso: `Stale` for descriptions of the available values for allowing stale views.
+     - Warning: This is an advanced option, it should not be used unless you fully understand the outcome of 
+     changing the value of this property.
+     */
+    var stale: Stale? { get set }
+    
+    var updateSeq: Bool? { get set }
+    
+    /**
+     Sets a handler to run for each row retrieved by the view.
+     
+     - parameter row: dictionary of the JSON data from the view row
+     */
+    var rowHandler: ((row: [String: AnyObject]) -> Void)? { get set }
+    
+}
+
+public extension ViewOperation {
+    
+    public func processResponse(json: Any) {
+        if let json = json as? [String: AnyObject] {
+            let rows = json["rows"] as! [[String: AnyObject]]
+            for row: [String: AnyObject] in rows {
+                self.rowHandler?(row: row)
+            }
+        }
+    }
+    
+    public var method: String {
+        get {
+            if keys != nil {
+                return "POST"
+            } else {
+                return "GET"
+            }
+        }
+    }
+    
+    /** 
+    Generates parameters for the following properties
+ 
+    * descending
+    * startKeyDocId
+    * endKeyDocId
+    * inclusiveEnd
+    * limit
+    * skip
+    * includeDocs
+    * conflicts
+     
+     
+    - Note: Implementing types *have* to add parameters which use the `associatedtype` `ViewParameter`
+    */
+    func generateParams() -> [String : String]{
+        var items: [String: String] = [:]
+        
+        if let descending = descending {
+            items["descending"] = "\(descending)"
+        }
+        
+        if let startKeyDocId = startKeyDocId {
+            items["startkey_docid"] = startKeyDocId
+        }
+        
+        if let endKeyDocId = endKeyDocId {
+            items["endkey_docid"] = "\(endKeyDocId)"
+        }
+        
+        if let inclusiveEnd = inclusiveEnd {
+            items["inclusive_end"] = "\(inclusiveEnd)"
+        }
+        
+        if let limit = limit {
+            items["limit"] = "\(limit)"
+        }
+        
+        if let skip = skip {
+            items["skip"] = "\(skip)"
+        }
+        
+        if let includeDocs = includeDocs {
+            items["include_docs"] = "\(includeDocs)"
+        }
+        
+        if let stale = stale {
+            items["stale"] = "\(stale)"
+        }
+        
+        if let conflicts = conflicts {
+            items["conflicts"] = "\(conflicts)"
+        }
+        
+        if let updateSeq = updateSeq {
+            items["update_seq"] = "\(updateSeq)"
+        }
+        
+        return items
+    }
+    
+    func convertJson(key: AnyObject) throws -> String {
+        if JSONSerialization.isValidJSONObject(key) {
+            let keyJson = try JSONSerialization.data(withJSONObject: key)
+            return String(data: keyJson, encoding: .utf8)!
+        } else if key is String {
+            // we need to quote JSON primitive strings
+            return "\"\(key)\""
+        } else {
+            // anything else we just try as stringified JSON value
+            return "\(key)"
+        }
+    }
+}

--- a/Tests/SwiftCloudant/GetAllDocsTest.swift
+++ b/Tests/SwiftCloudant/GetAllDocsTest.swift
@@ -1,0 +1,595 @@
+//
+//  GetAllDocsTest.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 05/07/2016.
+//  Copyright © 2016 IBM. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+
+import XCTest
+@testable import SwiftCloudant
+
+class GetAllDocsTest: XCTestCase {
+
+    lazy var dbName: String = { return self.generateDBName()}()
+    var client: CouchDBClient? = nil
+    
+    override func setUp() {
+        super.setUp()
+        
+        dbName = generateDBName()
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
+        createDatabase(databaseName: dbName, client: client!)
+        for doc in createTestDocuments(count: 10) {
+            let putDoc = PutDocumentOperation()
+            putDoc.databaseName = dbName
+            putDoc.body = doc
+            client?.add(operation: putDoc)
+        }
+    }
+    
+    override func tearDown() {
+        deleteDatabase(databaseName: dbName, client: client!)
+        
+        super.tearDown()
+        
+        print("Deleted database: \(dbName)")
+    }
+    
+    func createAllDocsOperation() -> GetAllDocsOperation {
+        let allDocs = GetAllDocsOperation()
+        allDocs.databaseName = dbName
+        allDocs.descending = true
+        allDocs.endKey = "endKey"
+        allDocs.includeDocs = true
+        allDocs.conflicts = true
+        allDocs.inclusiveEnd = true
+        allDocs.keys = ["keys","keys"]
+        allDocs.skip = 0
+        allDocs.limit = 25
+        allDocs.startKey = "startKey"
+        allDocs.startKeyDocId = "startKeyDocId"
+        allDocs.endKeyDocId = "endKeyDocId"
+        allDocs.stale = .Ok
+        allDocs.updateSeq = true
+        
+        allDocs.completionHandler = { (response, httpInfo, error) in
+            //do nothing.
+        }
+        allDocs.rowHandler = { (doc) in
+            // do nothing
+        }
+
+        return allDocs
+    }
+    
+    var expectedParams: [String: String] {
+        return ["descending":"true",
+                "endkey":"\"endKey\"",
+                "include_docs":"true",
+                "conflicts":"true",
+                "inclusive_end": "true",
+                "skip": "0",
+                "limit": "25",
+                "startkey": "\"startKey\"",
+                "stale": "ok",
+                "endkey_docid": "endKeyDocId",
+                "startkey_docid": "startKeyDocId",
+                "update_seq": "true"]
+    }
+    
+    func testAllDocsValidationMissingDBName(){
+        let allDocs = GetAllDocsOperation()
+        allDocs.completionHandler = { (response, httpInfo, error) in
+            //do nothing.
+        }
+        allDocs.rowHandler = { (doc) in
+            // do nothing
+        }
+        XCTAssertFalse(allDocs.validate())
+    }
+    
+    func testAllDocsValidationAllFieldsPresent(){
+        let allDocs = createAllDocsOperation()
+        allDocs.key = "myKey"
+        
+        allDocs.completionHandler = { (response, httpInfo, error) in
+            //do nothing.
+        }
+        allDocs.rowHandler = { (doc) in
+            // do nothing
+        }
+        XCTAssertFalse(allDocs.validate())
+    }
+    
+    func testValidationConfictsWithoutDocs(){
+        let allDocs = GetAllDocsOperation()
+        allDocs.databaseName = dbName
+        allDocs.conflicts = true
+        XCTAssertFalse(allDocs.validate())
+    }
+    
+    func testGenerateCorrectRequestAllOptions() throws {
+        let allDocs = createAllDocsOperation()
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        XCTAssertEqual(expectedParams,
+            allDocs.parameters)
+        
+    }
+    
+    func testGenerateRequestAscending() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.descending = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "descending")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateReuqestWithoutEndKey() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.endKey = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "endkey")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateReuqestWithoutDocs() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.includeDocs = nil
+        allDocs.conflicts = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "include_docs")
+        expectedParams.removeValue(forKey: "conflicts")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutConflicts() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.conflicts = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "conflicts")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWitoutInclusiveEnd() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.inclusiveEnd = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "inclusive_end")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutKey() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.key = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "key")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutKeysWithKey() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.keys = nil
+        allDocs.key = "mykey"
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("GET", allDocs.method)
+        XCTAssertNil(allDocs.data)
+        
+        var expectedParams = self.expectedParams
+        expectedParams["key"] = "\"mykey\""
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutSkip() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.skip = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "skip")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutLimit() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.limit = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "limit")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutStartKey() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.startKey = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "startkey")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutStartKeyDocId() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.startKeyDocId = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "startkey_docid")
+        
+        XCTAssertEqual(expectedParams,
+            allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutEndKeyDocId() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.endKeyDocId = nil
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "endkey_docid")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestWithoutStale() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.stale = nil
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams.removeValue(forKey: "stale")
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testGenerateRequestUpdateAfter() throws {
+        let allDocs = createAllDocsOperation()
+        allDocs.stale = .UpdateAfter
+        
+        XCTAssert(allDocs.validate())
+        try allDocs.serialise()
+        
+        XCTAssertEqual("POST", allDocs.method)
+        XCTAssertEqual("/\(dbName)/_all_docs", allDocs.endpoint)
+        
+        let data = allDocs.data
+        XCTAssertNotNil(data)
+        
+        if let data = data {
+            let requestData = try JSONSerialization.jsonObject(with: data) as? [String: [String]]
+            if let requestData = requestData {
+                XCTAssertNotNil(requestData)
+                XCTAssertEqual(["keys":["keys","keys"]], requestData)
+                
+            }
+        }
+        
+        var expectedParams = self.expectedParams
+        expectedParams["stale"] = "update_after"
+        
+        XCTAssertEqual(expectedParams,
+                       allDocs.parameters)
+    }
+    
+    func testEndToEndRequest() throws {
+        let expectation = self.expectation(withDescription: "AllDocs request")
+        
+        let allDocs = GetAllDocsOperation();
+        allDocs.databaseName = dbName
+        var docCount = 0
+        allDocs.rowHandler = { _ in
+            docCount += 1
+        }
+        allDocs.completionHandler = { response, info, error in
+        
+            XCTAssertNil(error)
+            XCTAssertNotNil(info)
+            if let info = info {
+                XCTAssertEqual(200, info.statusCode)
+            }
+            XCTAssertNotNil(response)
+            expectation.fulfill()
+        }
+        
+        client?.add(operation: allDocs)
+        
+        self.waitForExpectations(withTimeout: 10.0)
+    }
+    
+    func testDocumentPayload(){
+        let expectation = self.expectation(withDescription: "AllDocs request")
+        let rowHandler = self.expectation(withDescription: "doc handler")
+        
+        let allDocs = GetAllDocsOperation();
+        allDocs.databaseName = dbName
+        
+        allDocs.rowHandler = { doc in
+            XCTAssertEqual(["hello": "world"] as NSDictionary, doc)
+            rowHandler.fulfill()
+        }
+        allDocs.completionHandler = { response, info, error in
+            
+            XCTAssertNil(error)
+            XCTAssertNotNil(info)
+            if let info = info {
+                XCTAssertEqual(200, info.statusCode)
+            }
+            XCTAssertNotNil(response)
+            expectation.fulfill()
+        }
+        
+        simulateOkResponseFor(operation: allDocs, jsonResponse: ["rows":[["hello":"world"]]])
+        
+        self.waitForExpectations(withTimeout: 10.0)
+    }  
+
+}

--- a/Tests/SwiftCloudant/QueryViewTests.swift
+++ b/Tests/SwiftCloudant/QueryViewTests.swift
@@ -363,9 +363,26 @@ public class QueryViewTests: XCTestCase {
         XCTAssertEqual("GET", view.method)
         XCTAssertNil(view.data)
         XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1", view.endpoint)
-
+	
         let expectedQueryItems = ["stale": "update_after"]
 
+        XCTAssertEqual(expectedQueryItems, view.parameters)
+    }
+    
+    func testViewGeneratesCorrectRequestUpdateSeq() {
+        let view = QueryViewOperation()
+        view.designDoc = "ddoc"
+        view.viewName = "view1"
+        view.databaseName = self.dbName
+        view.updateSeq = true
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("GET", view.method)
+        XCTAssertNil(view.data)
+        XCTAssertEqual("/\(self.dbName!)/_design/ddoc/_view/view1", view.endpoint)
+        
+        let expectedQueryItems = ["update_seq": "true"]
+        
         XCTAssertEqual(expectedQueryItems, view.parameters)
     }
 }


### PR DESCRIPTION
## What

Added support for the `_all_docs` endpoint.

## How

- Create ViewOperation protocol to provide a place to implement common function between `_all_docs` and views.
- Added missing parameters to `QueryViewOperation` so it could conform to the ViewOperation protocol.
- Changed `limit` and `skip` to `UInt` since there is no value in allowing negative integers for these parameters.
- Moved `Stale` enum to outside of `QueryViewOperation` so it can be used with both `_all_docs` and `_view` endpoints. 

## Testing

New tests added in the AllDocsTests.swift.

## Issues

Resolves #89