### PR TITLE
Added an operation to get all documents from a database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [New] New GetAllDocumentsOperation API.
+
 # 0.3.2 (2016-07-08)
 
 - [FIXED] Created explicit `Sort` and `TextIndexField` initalizers so they are exposed as public.

--- a/Source/GetAllDocumentsOperation.swift
+++ b/Source/GetAllDocumentsOperation.swift
@@ -1,0 +1,245 @@
+//
+//  GetAllDocumentsOperation.swift
+//  SwiftCloudant
+//
+//
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ 
+ An operation to query database for all documents.
+ 
+ Example usage:
+ ```
+ let queryOp = GetAllDocumentsOperation()
+ queryOp.databaseName = dbName
+ queryOp.includeDocs = true // optional
+ queryOp.completionHandler = {(response, httpInfo, error) in
+   if error != nil {
+    // Example: handle an error by printing a message
+    print("Error: \(error)")
+   } else {
+    print("Response: \(response)")
+   }
+ }
+ 
+ // Add the operation to the database operation queue
+ dbClient.add(operation: queryOp)
+ ```
+ */
+public class GetAllDocumentsOperation: CouchDatabaseOperation, JsonOperation {
+  
+  public init() { }
+  
+  public var completionHandler: ((response: [String : AnyObject]?, httpInfo: HTTPInfo?, error: ErrorProtocol?) -> Void)?
+  public var databaseName: String?
+  
+  /**
+   Return the result rows in 'descending by key' order.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   */
+  public var descending: Bool? = nil
+  
+  /**
+   Return key/value result rows starting from the specified key.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   */
+  public var startKey: AnyObject? = nil
+
+  
+  /**
+   Stop the view returning result rows when the specified key is reached.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   */
+  public var endKey: AnyObject? = nil
+  
+  /**
+   Include result rows with the specified `endKey`.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   */
+  public var inclusiveEnd: Bool? = nil
+  
+  /**
+   Return only result rows that match the specified key.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   
+   - Warning: Cannot be used with `keys` option.
+   */
+  public var key: AnyObject? = nil
+  
+  /**
+   Return only result rows that match the specified keys.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   
+   - Warning: Cannot be used with `key` option.
+   */
+  public var keys: Array<AnyObject>? = nil
+  
+  /**
+   Limit the number of result rows returned from the view.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   */
+  public var limit: Int? = nil
+  
+  /**
+   The number of rows to skip in the view results.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   */
+  public var skip: Int? = nil
+  
+  /**
+   Include the full content of documents in the view results.
+   
+   - Note: Optional, if the property is unset this parameter will be omitted from the request and the server default will apply.
+   */
+  public var includeDocs: Bool? = nil
+  
+  /**
+   Sets a handler to run for each row retrieved by the view.
+   
+   - parameter row: dictionary of the JSON data from the view row
+   */
+  public var rowHandler: ((row: [String: AnyObject]) -> Void)?
+  
+  public func validate() -> Bool {
+    
+    if databaseName == nil {
+      return false
+    }
+
+    // Only one of key or keys can be used
+    if key != nil && keys != nil {
+      return false
+    }
+
+    return true
+  }
+  
+  public var method: String {
+    if (keys != nil) {
+      return "POST"
+    } else {
+      return "GET"
+    }
+  }
+  
+  public var data: NSData? {
+    if let keys = keys {
+      do {
+        #if os(Linux)
+          let keysDict: NSDictionary = ["keys".bridge() : keys.bridge()]
+        #else
+          let keysDict: NSDictionary = ["keys": keys as NSArray]
+        #endif
+        let keysJson = try NSJSONSerialization.data(withJSONObject: keysDict)
+        return keysJson
+      } catch {
+        callCompletionHandler(error: error)
+      }
+    }
+    return nil
+  }
+  
+  public var endpoint: String {
+    return "/\(self.databaseName!)/_all_docs"
+  }
+  
+  public var parameters: [String: String] {
+    get {
+      var items: [String: String] = [:]
+      
+      if let descending = descending {
+        items["descending"] = "\(descending)"
+      }
+      
+      if let startKeyJson = startKeyJson {
+        items["startkey"] = startKeyJson
+      }
+      
+      if let endKeyJson = endKeyJson {
+        items["endkey"] =  endKeyJson
+      }
+      
+      if let inclusiveEnd = inclusiveEnd {
+        items["inclusive_end"] = "\(inclusiveEnd)"
+      }
+      
+      if let keyJson = keyJson {
+        items["key"] = keyJson
+      }
+      
+      if let limit = limit {
+        items["limit"] = "\(limit)"
+      }
+      
+      if let skip = skip {
+        items["skip"] = "\(skip)"
+      }
+      
+      if let includeDocs = includeDocs {
+        items["include_docs"] = "\(includeDocs)"
+      }
+      
+      return items
+    }
+  }
+  
+  private var keyJson: String?
+  private var endKeyJson: String?
+  private var startKeyJson: String?
+  
+  public  func serialise() throws {
+    if let key = key {
+      keyJson = try convertJson(key: key)
+    }
+    if let endKey = endKey {
+      endKeyJson = try convertJson(key: endKey)
+    }
+    
+    if let startKey = startKey {
+      startKeyJson = try convertJson(key: startKey)
+    }
+    
+  }
+  
+  public func processResponse(json: Any) {
+    if let json = json as? [String: AnyObject] {
+      let rows = json["rows"] as! [[String: AnyObject]]
+      for row: [String: AnyObject] in rows {
+        self.rowHandler?(row: row)
+      }
+    }
+  }
+  
+  func convertJson(key: AnyObject) throws -> String {
+    if NSJSONSerialization.isValidJSONObject(key) {
+      let keyJson = try NSJSONSerialization.data(withJSONObject: key)
+      return String(data: keyJson, encoding: NSUTF8StringEncoding)!
+    } else if key is String {
+      // we need to quote JSON primitive strings
+      return "\"\(key)\""
+    } else {
+      // anything else we just try as stringified JSON value
+      return "\(key)"
+    }
+  }
+}

--- a/Source/GetAllDocumentsOperation.swift
+++ b/Source/GetAllDocumentsOperation.swift
@@ -19,6 +19,7 @@ import Foundation
 /**
  
  An operation to query database for all documents.
+ For info on parameters, view this https://docs.cloudant.com/database.html#get-documents
  
  Example usage:
  ```

--- a/Source/QueryViewOperation.swift
+++ b/Source/QueryViewOperation.swift
@@ -25,7 +25,6 @@ import Foundation
  Example usage:
  ```
  let view = QueryViewOperation()
- view.dbName = "example"
  view.designDoc = "exampleDesignDoc"
  view.viewName = "exampleView"
  view.databaseName = "exampledb"

--- a/Tests/SwiftCloudant/GetAllDocumentsTests.swift
+++ b/Tests/SwiftCloudant/GetAllDocumentsTests.swift
@@ -1,0 +1,215 @@
+//
+//  GetAllDocumentsTests.swift
+//  SwiftCloudant
+//
+//  Created by Taylor Franklin on 7/8/16.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+
+public class GetAllDocumentsTests : XCTestCase {
+
+    var client: CouchDBClient? = nil;
+    var dbName: String? = nil
+    let response = ["offset": 0,
+                    "rows": [["id": "3-tiersalmonspinachandavocadoterrine",
+                              "key": "3-tier salmon, spinach and avocado terrine",
+                              "value": ["3-tier salmon, spinach and avocado terrine"]],
+                             ["id": "Aberffrawcake",
+                              "key": "Aberffraw cake",
+                              "value": ["Aberffraw cake"]],
+                             ["id": "Adukiandorangecasserole-microwave",
+                              "key": "Aduki and orange casserole - microwave",
+                              "value": ["Aduki and orange casserole - microwave"]],
+                             ["id": "Aioli-garlicmayonnaise",
+                              "key": "Aioli - garlic mayonnaise",
+                              "value": ["Aioli - garlic mayonnaise"]],
+                             ["id": "Alabamapeanutchicken",
+                              "key": "Alabama peanut chicken",
+                              "value": ["Alabama peanut chicken"]]],
+                    "total_rows": 2667]
+    
+    public override func setUp() {
+        super.setUp()
+        
+        dbName = generateDBName()
+        client = CouchDBClient(url: NSURL(string:self.url)!, username: self.username, password: self.password)
+    }
+    
+    override public func tearDown() {
+        super.tearDown()
+    }
+    
+    func testViewGeneratesCorrectRequestUsingStartAndEndKeys() throws {
+        let view = GetAllDocumentsOperation()
+        view.descending = true
+        view.endKey = "endkey"
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.startKey = "startKey"
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        try view.serialise()
+        
+        XCTAssertEqual("GET", view.method)
+        XCTAssertNil(view.data)
+        XCTAssertEqual("/\(self.dbName!)/_all_docs", view.endpoint)
+        
+        let expectedQueryItems = ["descending": "true",
+              "endkey": "\"endkey\"",
+              "include_docs": "true",
+              "inclusive_end": "true",
+              "limit": "4",
+              "skip": "0",
+              "startkey": "\"startKey\""]
+        
+        XCTAssertEqual(expectedQueryItems, view.parameters)
+    }
+    
+    func testViewGeneratesCorrectRequestUsingJsonStartAndEndKeys() throws {
+        let view = GetAllDocumentsOperation()
+        view.descending = true
+        view.endKey = ["endkey", "endkey2"]
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.startKey = ["startKey", "startKey2"]
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        try view.serialise()
+        
+        XCTAssertEqual("GET", view.method)
+        XCTAssertNil(view.data)
+        XCTAssertEqual("/\(self.dbName!)/_all_docs", view.endpoint)
+        
+        let expectedQueryItems = ["descending": "true",
+              "endkey": "[\"endkey\",\"endkey2\"]",
+              "include_docs": "true",
+              "inclusive_end": "true",
+              "limit": "4",
+              "skip": "0",
+              "startkey": "[\"startKey\",\"startKey2\"]"]
+        
+        XCTAssertEqual(expectedQueryItems, view.parameters)
+    }
+    
+    func testViewGeneratesCorrectRequestUsingKey() throws {
+        let view = GetAllDocumentsOperation()
+        view.descending = true
+        view.key = "testKey"
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        try view.serialise()
+        
+        XCTAssertEqual("GET", view.method)
+        XCTAssertNil(view.data)
+        XCTAssertEqual("/\(self.dbName!)/_all_docs", view.endpoint)
+        
+        let expectedQueryItems = ["descending": "true",
+                                  "key": "\"testKey\"",
+                                  "include_docs": "true",
+                                  "inclusive_end": "true",
+                                  "limit": "4",
+                                  "skip": "0"]
+        print("View: \(view.parameters)")
+        XCTAssertEqual(expectedQueryItems, view.parameters)
+    }
+    
+    func testViewGeneratesCorrectRequestUsingKeys() {
+        let view = GetAllDocumentsOperation()
+        view.descending = true
+        view.keys = ["testkey", ["testkey2", "testkey3"]]
+        view.includeDocs = true
+        view.inclusiveEnd = true
+        view.limit = 4
+        view.skip = 0
+        view.databaseName = self.dbName
+        
+        XCTAssert(view.validate())
+        XCTAssertEqual("POST", view.method)
+        XCTAssertNotNil(view.data)
+        XCTAssertEqual("{\"keys\":[\"testkey\",[\"testkey2\",\"testkey3\"]]}",
+                       String(data: view.data!, encoding: NSUTF8StringEncoding))
+        XCTAssertEqual("/\(self.dbName!)/_all_docs", view.endpoint)
+        
+        let expectedQueryItems = ["descending": "true",
+                                  "include_docs": "true",
+                                  "inclusive_end": "true",
+                                  "limit": "4",
+                                  "skip": "0"]
+        
+        XCTAssertEqual(expectedQueryItems, view.parameters)
+    }
+    
+    func testViewHandlesResponsesCorrectly() {
+        let view = GetAllDocumentsOperation()
+        view.databaseName = dbName
+        
+        var rowCount = 0
+        var first = true
+        let rowHandler = self.expectation(withDescription: "row handler")
+        let completionHandler = self.expectation(withDescription: "completion handler")
+        view.rowHandler = { (row) in
+            if (first) {
+                rowHandler.fulfill()
+                first = false
+            }
+            rowCount += 1
+            XCTAssertNotNil(row)
+        }
+        
+        view.completionHandler = { (response, httpInfo, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(response)
+            XCTAssertNotNil(httpInfo)
+            if let httpInfo = httpInfo {
+                XCTAssert(httpInfo.statusCode / 100 == 2)
+            }
+            completionHandler.fulfill()
+        }
+        self.simulateOkResponseFor(operation: view, jsonResponse:JSONResponse(dictionary: response))
+        self.waitForExpectations(withTimeout: 10.0, handler: nil)
+    }
+    
+    func testOperationValidationKeyAndKeys() {
+        let view = GetAllDocumentsOperation()
+        view.databaseName = "dbname"
+        view.key = "key"
+        view.keys = ["key1", "key2"]
+        XCTAssertFalse(view.validate())
+    }
+    
+    func testOperationValidationNoCompletionHandlers() {
+        let view = GetAllDocumentsOperation()
+        view.databaseName = "dbname"
+        XCTAssert(view.validate())
+    }
+    
+    func testOperationValidationMissingDBName() {
+        let view = GetAllDocumentsOperation()
+        XCTAssertFalse(view.validate())
+    }
+
+}


### PR DESCRIPTION
- [x] You have signed the CLA as per the instructions in [CONTRIBUTING.md](https://github.com/cloudant/swift-cloudant/blob/master/CONTRIBUTING.md#contributor-license-agreement)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/cloudant/swift-cloudant/blob/master/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

Added a new API: `GetAllDocumentsOperation`.
Issue #105 explains a little bit more, but I needed this functionality for my application and found it to be present in other cloudant libraries, such as the Java one.

## How

The `GetAllDocumentsOperation` class is very similar to the `QueryViewOperation` class, but is much simpler and needs to hit a different endpoint.

## Testing

Once again, wrote tests that are similar to `QueryViewTests`, changing when necessary.

## Issues

Resolves #105 
If this PR is accepted, you will just need to adjust the Foundation API calls for Swift 3 preview after you merge into master branch.
