### PR TITLE
Support `_bulk_docs`

### DIFF
--- a/Source/BulkDocs.swift
+++ b/Source/BulkDocs.swift
@@ -1,0 +1,121 @@
+//
+//  BulkDocs.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 27/07/2016.
+//
+//  Copyright (C) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+
+/**
+ An operation to create and update documents in bulk.
+ 
+ Example usage:
+ 
+ ```
+ let documents = [["hello":"world"], ["foo":"bar", "_id": "foobar", "_rev": "1-revision"]]
+ let bulkDocs = PutBulkDocsOperation(databaseName: "exampleDB", documents: documents) { response, httpInfo, error in 
+    guard let response = response, httpInfo = httpInfo, error == nil 
+    else {
+        //handle the error
+        return
+    }
+ 
+    //handle success.
+ }
+ 
+ ```
+ */
+public class PutBulkDocsOperation : CouchDatabaseOperation, JSONOperation {
+    
+    public typealias Json = [[String: AnyObject]]
+
+    public let databaseName: String
+    
+    public let completionHandler: ((response: [[String:AnyObject]]?, httpInfo:HTTPInfo?, error:Error?) -> Void)?
+    
+    /**
+     The documents that make up this request.
+    */
+    public let documents: [[String:AnyObject]]
+    
+    /**
+     If false, CouchDB will not assign documents new revision IDs. This option is normally
+     used for replication with CouchDB.
+    */
+    public let newEdits: Bool?
+    
+    /**
+    If true the commit mode for the request will be "All or Nothing" meaning that if one document
+    fails to be created or updated, no documents will be commited to the database.
+    */
+    public let allOrNothing: Bool?
+    
+    /**
+     Creates the operation
+     
+     - parameter databaseName: The name of the database where the documents should be created or updated.
+     - parameter documents: The documents that should be saved to the server.
+     - parameter newEdits: Should the server treat the request as new edits or save as is.
+     - parameter allOrNothing: The commit mode for the database, if set to true, if one document fails
+     to be inserted into the database, all other documents in the request will also not be inserted.
+     - parameter completionHandler: Optional handler to call when the operation completes.
+     */
+    public init(databaseName: String,
+                documents:[[String:AnyObject]],
+                newEdits: Bool? = nil,
+                allOrNothing: Bool? = nil,
+                completionHandler: ((response: [[String:AnyObject]]?, httpInfo:HTTPInfo?, error:Error?) -> Void)? = nil){
+        self.databaseName = databaseName
+        self.documents = documents
+        self.newEdits = newEdits
+        self.allOrNothing = allOrNothing
+        self.completionHandler = completionHandler
+    }
+    
+    public var endpoint: String {
+        return "/\(databaseName)/_bulk_docs"
+    }
+    
+    public func validate() -> Bool {
+        return JSONSerialization.isValidJSONObject(documents)
+    }
+    
+    
+    private var jsonData: Data?
+    
+    public func serialise() throws {
+        var request:[String:AnyObject] = ["docs":documents]
+        
+        if let newEdits = newEdits {
+            request["new_edits"] = newEdits
+        }
+        
+        if let allOrNothing = allOrNothing {
+            request["all_or_nothing"] = allOrNothing
+        }
+        
+        jsonData = try JSONSerialization.data(withJSONObject: request);
+    }
+    
+    public var data: Data? {
+        return jsonData
+    }
+    
+    public var method:String {
+        return "POST"
+    }
+
+
+}
+

--- a/Tests/SwiftCloudant/BulkDocsTests.swift
+++ b/Tests/SwiftCloudant/BulkDocsTests.swift
@@ -1,0 +1,167 @@
+//
+//  BulkDocsTests.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 27/07/2016.
+//
+//  Copyright (C) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+class BulkDocsTests : XCTestCase {
+    
+    var dbName: String? = nil
+    var client: CouchDBClient? = nil
+    let docs:[[String:AnyObject]] = [["hello":"world"], ["foo": "bar"]]
+    
+    override func setUp() {
+        super.setUp()
+        self.dbName = generateDBName()
+        client = CouchDBClient(url: URL(string: url)!, username: username, password: password)
+        createDatabase(databaseName: dbName!, client: client!)
+    }
+    
+    override func tearDown() {
+        deleteDatabase(databaseName: dbName!, client: client!)
+        super.tearDown()
+    }
+    
+    func testValidationOnlyDocs() {
+    
+        
+        let bulk = PutBulkDocsOperation(databaseName: dbName!, documents: docs)
+        XCTAssert(bulk.validate())
+    }
+    
+    func testValidationNewEdits() {
+        
+        let bulk = PutBulkDocsOperation(databaseName: dbName!, documents: docs, newEdits: false)
+        XCTAssert(bulk.validate())
+    }
+    
+    func testValidationAllOrNothing() {
+        
+        let bulk = PutBulkDocsOperation(databaseName: dbName!, documents: docs, allOrNothing: true)
+        XCTAssert(bulk.validate())
+    }
+    
+    func testGeneratedPayloadAllOptions() throws {
+        
+        let bulk = PutBulkDocsOperation(databaseName: dbName!, documents: docs, newEdits: false, allOrNothing: true)
+        XCTAssert(bulk.validate())
+        
+        try bulk.serialise()
+        
+        let data =  bulk.data
+        XCTAssertNotNil(data)
+        
+        XCTAssertEqual("POST", bulk.method)
+        if let data = data {
+            
+            let requestJson = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+            
+            XCTAssertEqual(["docs":[["hello":"world"],["foo":"bar"]], "new_edits":false, "all_or_nothing":true] as NSDictionary, requestJson)
+        }
+    }
+   
+    func testGeneratedPayloadNewEdits() throws {
+        
+        let bulk = PutBulkDocsOperation(databaseName: dbName!, documents: docs, newEdits: false)
+        XCTAssert(bulk.validate())
+        
+        try bulk.serialise()
+        
+        let data =  bulk.data
+        XCTAssertNotNil(data)
+        
+        XCTAssertEqual("POST", bulk.method)
+        if let data = data {
+            
+            let requestJson = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+            
+            XCTAssertEqual(["docs":[["hello":"world"],["foo":"bar"]], "new_edits":false] as NSDictionary, requestJson)
+        }
+    }
+    
+    func testGeneratedPayloadAllOrNothing() throws {
+        
+        let bulk = PutBulkDocsOperation(databaseName: dbName!, documents: docs, allOrNothing: true)
+        XCTAssert(bulk.validate())
+        
+        try bulk.serialise()
+        
+        let data =  bulk.data
+        XCTAssertNotNil(data)
+        
+        XCTAssertEqual("POST", bulk.method)
+        if let data = data {
+            
+            let requestJson = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+            
+            XCTAssertEqual(["docs":[["hello":"world"],["foo":"bar"]], "all_or_nothing":true] as NSDictionary, requestJson)
+        }
+    }
+    
+    func testCompleteRequest() throws {
+        let expectation = self.expectation(description: "bulk insert")
+        
+        let bulk = PutBulkDocsOperation(databaseName: dbName!, documents: docs) { (response, httpInfo, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(response)
+            XCTAssertNotNil(httpInfo)
+            
+            if let httpInfo = httpInfo {
+                XCTAssert(httpInfo.statusCode / 100 == 2)
+            }
+            
+            if let response = response {
+                XCTAssertEqual(2,response.count)
+                
+                for doc in response {
+                    
+                    if let ok = doc["ok"] as? Bool {
+                        XCTAssertEqual(true, ok)
+                    }
+                    
+                }
+            }
+            expectation.fulfill()
+        
+        }
+        
+        client?.add(operation: bulk)
+        self.waitForExpectations(timeout: 10.0)
+        
+        // Check that all the documents are in the db
+        let getDocsExpect = self.expectation(description: "get all docs")
+        let allDocs = GetAllDocsOperation(databaseName: dbName!){ (response, httpInfo, error) in
+            
+            XCTAssertNotNil(response)
+            XCTAssertNotNil(httpInfo)
+            XCTAssertNil(error)
+            
+            if let response = response, let httpInfo = httpInfo {
+                XCTAssertEqual(2, httpInfo.statusCode / 100)
+                XCTAssertNotNil(response["rows"])
+                if let rows = response["rows"] as? [String] {
+                    XCTAssertEqual(2, rows.count)
+                }
+            }
+            getDocsExpect.fulfill()
+        }
+        self.client?.add(operation: allDocs)
+        self.waitForExpectations(timeout: 10.0)
+    }
+    
+}


### PR DESCRIPTION
## What

Support `_bulk_docs`
## How

Created `PutBulkDocsOperation` API.

## Testing

Several tests, mostly aimed at the data the operation produced , a single test which goes through the whole HTTP stack.

## Issues

Resolves #88