### PR TITLE
Optionally back off when 429 is sent by the server

### DIFF
--- a/Source/CouchClient.swift
+++ b/Source/CouchClient.swift
@@ -15,6 +15,50 @@
 //
 
 import Foundation
+import Dispatch
+
+/**
+ Configures an instance of CouchDBClient.
+ */
+public struct ClientConfiguration {
+    /**
+     Should the client back off when a 429 response is encountered. Backing off will result 
+     in the client retrying the request at a later time.
+     */
+    public var shouldBackOff: Bool
+    /**
+     The number of attempts the client should make to back off and get a successful response
+     from server.
+     
+     - Note: The maximum is hard limited by the client to 10 retries.
+     */
+    public var backOffAttempts: UInt
+    
+    /**
+     The initial value to use when backing off.
+     
+     - Remark: The client uses a doubling back off when a 429 reponse is encountered, so care is required when selecting
+     the initial back off value and the number of attempts to back off and successfully retreive a response from the server.
+     */
+    public var initialBackOff:DispatchTimeInterval
+    
+    /**
+     Creates an ClientConfiguration
+     - parameter shouldBackOff: Should the client automatically back off.
+     - parameter backOffAttempts: The number of attempts the client should make to back off and 
+     get a successful response. Default 3.
+     - parameter initialBackOff: The time to wait before retrying when the first 429 response is received,
+     this value will be doubled for each subsequent back off
+     
+     */
+    public init(shouldBackOff: Bool, backOffAttempts: UInt = 3, initialBackOff: DispatchTimeInterval =  .milliseconds(250)){
+        self.shouldBackOff = shouldBackOff
+        self.backOffAttempts = backOffAttempts
+        self.initialBackOff = initialBackOff
+    }
+    
+}
+
 
 /**
  Class for running operations against a CouchDB instance.
@@ -33,8 +77,12 @@ public class CouchDBClient {
      - parameter url: url of the server to connect to.
      - parameter username: the username to use when authenticating.
      - parameter password: the password to use when authenticating.
+     - parameter configuration: configuration options for the client.
      */
-    public init(url: URL, username: String?, password: String?) {
+    public init(url: URL,
+                username: String?,
+                password: String?,
+                configuration: ClientConfiguration = ClientConfiguration(shouldBackOff: false)) {
         self.rootURL = url
         self.username = username
         self.password = password
@@ -47,8 +95,13 @@ public class CouchDBClient {
         } else {
             interceptors = []
         }
-
-        self.session = InterceptableSession(delegate: nil, requestInterceptors: interceptors)
+        
+        let sessionConfiguration = InterceptableSessionConfiguration(shouldBackOff: configuration.shouldBackOff,
+                                                                     backOffRetries: configuration.backOffAttempts,
+                                                                     initialBackOff: configuration.initialBackOff,
+                                                              requestInterceptors: interceptors)
+        
+        self.session = InterceptableSession(delegate: nil, configuration: sessionConfiguration)
 
     }
 

--- a/Tests/SwiftCloudantTests/InterceptableSessionTests.swift
+++ b/Tests/SwiftCloudantTests/InterceptableSessionTests.swift
@@ -1,0 +1,277 @@
+//
+//  InterceptableSessionTests.swift
+//  SwiftCloudant
+//
+//  Created by Rhys Short on 19/08/2016.
+//
+//  Copyright (C) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+
+class InterceptableSessionTests : XCTestCase {
+    
+    
+    lazy var sessionConfig = {() -> URLSessionConfiguration in
+        let config = URLSessionConfiguration.default
+        config.protocolClasses = [BackOffHTTPURLProtocol.self]
+        return config
+    
+    }()
+    
+    func testInterceptableSessionBacksOff() throws {
+        let session = InterceptableSession(delegate: nil, configuration: InterceptableSessionConfiguration(shouldBackOff:true))
+        session.session = URLSession(configuration: sessionConfig, delegate: session, delegateQueue: nil)
+        
+        guard let url = URL(string:"http://example.com") else {
+            XCTFail("Failed to create url with http://example.com")
+            return
+        }
+        
+        let request = URLRequest(url: url)
+        
+        
+        let delegate = BackOffRequestDelegate(expectation: self.expectation(description:"429 back off request"))
+        let task = session.dataTask(request: request, delegate: delegate)
+        task.resume() // start the task processing.
+        
+        self.waitForExpectations(timeout: 10.0)
+        
+        XCTAssertEqual(2, remainingBackOffRetries(for: task))
+        XCTAssertEqual(200, delegate.response?.statusCode)
+        XCTAssertNil(delegate.error)
+        XCTAssertNotNil(delegate.data)
+        XCTAssertEqual(9, remainingTotalRetries(for: task))
+    }
+    
+    
+    func testInterceptableSessionBackOffMax() throws {
+        let config = sessionConfig
+        config.protocolClasses = [AlwaysBackOffHTTPURLProtocol.self]
+        
+        let session = InterceptableSession(delegate: nil, configuration: InterceptableSessionConfiguration(shouldBackOff:true))
+        session.session = URLSession(configuration: config, delegate: session, delegateQueue: nil)
+        
+        guard let url = URL(string:"http://example.com") else {
+            XCTFail("Failed to create url with http://example.com")
+            return
+        }
+        
+        let request = URLRequest(url: url)
+        
+        
+        let delegate = BackOffRequestDelegate(expectation: self.expectation(description:"429 back off request"))
+        let task = session.dataTask(request: request, delegate: delegate)
+        task.resume() // start the task processing.
+        
+        self.waitForExpectations(timeout: 10.0)
+        
+        XCTAssertEqual(0, remainingBackOffRetries(for: task))
+        XCTAssertEqual(429, delegate.response?.statusCode)
+        XCTAssertNil(delegate.error)
+        XCTAssertNotNil(delegate.data)
+        XCTAssertEqual(7, remainingTotalRetries(for: task))
+    }
+    
+    func testBackSetHigherThanAllowedRetries() throws {
+        let config = sessionConfig
+        config.protocolClasses = [AlwaysBackOffHTTPURLProtocol.self]
+        
+        let session = InterceptableSession(delegate: nil, configuration: InterceptableSessionConfiguration(maxRetries: 3, shouldBackOff:true, backOffRetries: 4))
+        session.session = URLSession(configuration: config, delegate: session, delegateQueue: nil)
+        
+        guard let url = URL(string:"http://example.com") else {
+            XCTFail("Failed to create url with http://example.com")
+            return
+        }
+        
+        let request = URLRequest(url: url)
+        
+        
+        let delegate = BackOffRequestDelegate(expectation: self.expectation(description:"429 back off request"))
+        let task = session.dataTask(request: request, delegate: delegate)
+        task.resume() // start the task processing.
+        
+        self.waitForExpectations(timeout: 20.0)
+        
+        XCTAssertEqual(1, remainingBackOffRetries(for: task))
+        XCTAssertEqual(429, delegate.response?.statusCode)
+        XCTAssertNil(delegate.error)
+        XCTAssertNotNil(delegate.data)
+        XCTAssertEqual(0, remainingTotalRetries(for: task))
+    }
+    
+    func test429ConfiguredViaClient() throws {
+        
+        let expectation = self.expectation(description: "429 from example.com")
+        
+        let client = CouchDBClient(url: URL(string: "http://example.com")!,
+                                   username: username,
+                                   password: password,
+                                   configuration: ClientConfiguration(shouldBackOff:true))
+        let config = sessionConfig
+        config.protocolClasses = [AlwaysBackOffHTTPURLProtocol.self]
+        
+        //get the seesion from the client.
+        
+        guard let session = interceptableSession(for: client)
+        else {
+            XCTFail("Failed to get session instance from client")
+            return
+        }
+        session.session = URLSession(configuration: config, delegate: session, delegateQueue: nil)
+        
+        let createDB = CreateDatabaseOperation(name: "test") {(response, info, error) in
+            XCTAssertNotNil(response)
+            XCTAssertNotNil(info)
+            XCTAssertNotNil(error)
+            if let info = info {
+                XCTAssertEqual(429, info.statusCode)
+            }
+            expectation.fulfill()
+        }
+        
+        client.add(operation: createDB)
+        self.waitForExpectations(timeout: 10.0)
+    
+    
+    }
+    
+    func testInterceptableSessionNoBackOff() throws {
+        let config = sessionConfig
+        config.protocolClasses = [AlwaysBackOffHTTPURLProtocol.self]
+        let session = InterceptableSession(delegate: nil, configuration: InterceptableSessionConfiguration(shouldBackOff: false))
+        session.session = URLSession(configuration: config, delegate: session, delegateQueue: nil)
+        
+        guard let url = URL(string:"http://example.com") else {
+            XCTFail("Failed to create url with http://example.com")
+            return
+        }
+        
+        let request = URLRequest(url: url)
+        
+        
+        let delegate = BackOffRequestDelegate(expectation: self.expectation(description:"429 back off request"))
+        let task = session.dataTask(request: request, delegate: delegate)
+        task.resume() // start the task processing.
+        
+        self.waitForExpectations(timeout: 10.0)
+        
+        XCTAssertEqual(3, remainingBackOffRetries(for: task))
+        XCTAssertEqual(429, delegate.response?.statusCode)
+        XCTAssertNil(delegate.error)
+        XCTAssertNotNil(delegate.data)
+        XCTAssertEqual(10, remainingTotalRetries(for: task))
+    }
+    
+    func remainingBackOffRetries(for task: SwiftCloudant.URLSessionTask) -> Int {
+        return value(of: "remainingBackOffRetries", for: task)
+    }
+    
+    func remainingTotalRetries(for task: SwiftCloudant.URLSessionTask) -> Int {
+        return value(of: "remainingRetries", for: task)
+    }
+    
+    func value(of key:String, for task: SwiftCloudant.URLSessionTask) -> Int {
+        let mirror = Mirror(reflecting: task);
+        let values = mirror.children.filter { (innerKey, value) in
+                return innerKey == key
+            }.first
+        
+        if let value = values?.value as? UInt {
+            return Int(value)
+        }
+        
+        return -1
+    }
+    
+    func interceptableSession(for client:CouchDBClient) -> InterceptableSession? {
+        let mirror = Mirror(reflecting: client);
+        let values = mirror.children.filter { (key, value) in
+            return key == "session"
+            }.first
+        
+        if let value = values?.value as? InterceptableSession {
+            return value
+        }
+    
+        return nil
+
+    }
+    
+    
+}
+
+// We need reference type semantics here.
+class BackOffRequestDelegate: InterceptableSessionDelegate {
+    
+    private let expectation:XCTestExpectation
+    var response: HTTPURLResponse?
+    var data: Data = Data()
+    var error: Error?
+    
+    init(expectation: XCTestExpectation){
+        self.expectation = expectation
+    }
+    
+    
+    func received(response:HTTPURLResponse) {
+        self.response = response
+    }
+    
+    func received(data: Data){
+        self.data.append(data)
+    }
+    
+    func completed(error: Swift.Error?){
+        self.error = error
+        self.expectation.fulfill()
+    }
+}
+
+
+class BackOffHTTPURLProtocol: CookieSessionHTTPURLProtocol {
+    
+    static var shouldBackOff = true
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        return request.url!.host! == "example.com"
+    }
+    
+    override func startLoading() {
+        if BackOffHTTPURLProtocol.shouldBackOff {
+            sendResponse(statusCode: 429, json: [:])
+            BackOffHTTPURLProtocol.shouldBackOff = false
+        } else {
+            BackOffHTTPURLProtocol.shouldBackOff = true
+            sendResponse(statusCode: 200, json: [:])
+            
+        }
+    }
+}
+
+class AlwaysBackOffHTTPURLProtocol: CookieSessionHTTPURLProtocol {
+    
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        return request.url!.host! == "example.com"
+    }
+    
+    override func startLoading() {
+        sendResponse(statusCode: 429, json: [:])
+    }
+}
+
+

--- a/Tests/SwiftCloudantTests/TestHelpers.swift
+++ b/Tests/SwiftCloudantTests/TestHelpers.swift
@@ -20,6 +20,7 @@ import XCTest
 
 // Extension to add functions for commonly used operations in tests.
 extension XCTestCase {
+    
 
     var url: String {
         get {


### PR DESCRIPTION
## What

Add support for optionally backing off when a `429` response is received from the server.

## How

- Use a dispatch queue for processing the responses from the server, not including the data.
- When a `429` is encountered, dispatch with a delay, starting at 250 milliseconds , doubling for each retry. 
- Limit back off retries to `10` the current hard limit for interceptor driven retries.
- Added a required configuration argument to the `CouchDBClient` init method, this sets if the client should back off, and how many times it should attempt to back off.

## Testing

Tests added to `InterceptableSessionTests`

## Issues

Resolves #11