### PR TITLE
Enable swift testing on linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,30 @@
-language: objective-c
-osx_image: xcode8
-
-before_script:
-  - brew install couchdb
-  - brew services start couchdb
+language: generic
 
 script:
   - swift build && swift test
+
+matrix:
+  allow_failures:
+    - os: linux
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      before_script:
+          - sudo apt-get update
+          - sudo apt-get install -y build-essential git libcurl3 libblocksruntime-dev clang libicu-dev uuid-dev
+          - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
+          - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
+          - wget https://swift.org/builds/swift-3.0-release/ubuntu1404/swift-3.0-RELEASE/swift-3.0-RELEASE-ubuntu14.04.tar.gz
+          - gunzip swift-3.0-RELEASE-ubuntu14.04.tar.gz
+          - tar -xvf swift-3.0-RELEASE-ubuntu14.04.tar
+          - export PATH=${PWD}/swift-3.0-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
+    - os: osx
+      language: objective-c
+      osx_image: xcode8
+      before_script:
+        - brew install couchdb
+        - brew services start couchdb
+
+services:
+    - couchdb


### PR DESCRIPTION
## What

Add Linux builds to travis matrix.

## How

- Add `matrix` key to travis file
- Set overall language to `c` since there isn't a swift.
- Allow Linux builds to fail and not effect the build outcome, this allows
   linux support to be phased in gradually.
