### PR TITLE
Fix issue where 401 response triggers infinite loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- [FIXED] Resolved issue where an infinite retry loop would be triggered if
+  a `401: Forbidden` response was always received from an endpoint.
+
 # 0.6.0 (2016-09-16)
 
 - [NEW] Support for Swift 3.0 Release for Darwin Platforms.
@@ -8,7 +13,7 @@
 - [NEW] New `ViewPager` API.
 - [FIXED] Correctly handle differences between CouchDb and Cloudant for cookie expiration.
 
-# 0.5.0 
+# 0.5.0
 
 - [NEW] Support Swift SNAPSHOT 2016-07-26
 

--- a/Source/URLSession.swift
+++ b/Source/URLSession.swift
@@ -259,8 +259,10 @@ internal class InterceptableSession: NSObject, URLSessionDelegate, URLSessionTas
                 let json = try? JSONSerialization.jsonObject(with: data)
                 if let json =  json as? [String: Any],
                     let  errorMessage = json["error"] as? String,
-                    ( errorMessage == "credentials_expired" || response.statusCode == 401 ) { // only 403 may have this message.
+                    ( errorMessage == "credentials_expired" || response.statusCode == 401 ),
+                    mTask.remainingRetries > 0 { // only 403 may have this message.
                     // we need to get a new cookie and retry the request.
+                    mTask.remainingRetries -= 1
                     self.requestCookie(url: mTask.request.url!)
                     
                     //clear the task cache


### PR DESCRIPTION
## What

Correct issue where constant 401 responses from an endpoint would cause an infinite retry loop.

## How
Decrement remainingRetries counter and check that is greater than zero before attempting to 
retry the request.

## Testing

Added a new test, and modified `CookieSession401` URLProtocol response to contain the `error` key.

## Issues

Fixes #135