### PR TITLE
Fix crash on deallocate for unused client

### DIFF
--- a/Source/SwiftCloudant/HTTP/URLSession.swift
+++ b/Source/SwiftCloudant/HTTP/URLSession.swift
@@ -161,6 +161,9 @@ internal class URLSessionTask {
  */
 internal class InterceptableSession: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate, URLSessionStreamDelegate {
 
+    // This is lazy because of swift init rules. We can't use self for the delegate until super.init is called, but we
+    // can't call super.init until all properties have been initialised. To get around this we lazily create the
+    // URLSession instance when it is required.
     internal lazy var session: URLSession = { () -> URLSession in
         let config = URLSessionConfiguration.default
         #if os(Linux)
@@ -439,7 +442,9 @@ internal class InterceptableSession: NSObject, URLSessionDelegate, URLSessionTas
     }
 
     deinit {
-        self.session.finishTasksAndInvalidate()
+        if !isFirstRequest {
+            self.session.finishTasksAndInvalidate()
+        }
     }
 
     private class func userAgent() -> String {

--- a/Tests/SwiftCloudantTests/CouchClientTest.swift
+++ b/Tests/SwiftCloudantTests/CouchClientTest.swift
@@ -1,0 +1,30 @@
+//
+//  CouchClientTest.swift
+//  SwiftCloudant
+//
+//  Created by Sam Smith on 19/12/2016.
+//
+//
+
+import Foundation
+import XCTest
+@testable import SwiftCloudant
+
+class CouchClientTest: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testCanAllocateAndDeallocateCouchDBClient() {
+        // Previously client would cause a crash where we deallocated an unsued client, i.e. no requests have been made.
+        let url = URL(string: "https://example:xxxxxxx@example.cloudant.com")!
+        let _ = CouchDBClient(url: url, username: url.user, password: url.password)
+    }
+}


### PR DESCRIPTION
## What
Fix crash on deallocate for unused client.

## How
Only call `self.session.finishTasksAndInvalidate()` if the client has received a request. 

## Testing
Add additional unit test to instantiate an unused client.
