### PR TITLE
Changed the downcasting from [String:NSObject] to [String:Any]

### DIFF
--- a/Tests/SwiftCloudantTests/FindDocumentOperationTests.swift
+++ b/Tests/SwiftCloudantTests/FindDocumentOperationTests.swift
@@ -159,7 +159,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
         
             do {
-                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:Any]
                 
                 let expected:[String:Any] = ["selector":["foo":"bar"],
                                 "fields":["foo","bar"],
@@ -198,7 +198,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
             
             do {
-                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:Any]
                 
                 let expected:[String: Any] = ["selector":["foo":"bar"],
                                                   "sort": [["foo":"asc"]],
@@ -231,7 +231,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
             
             do {
-                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:Any]
                 
                 let expected:[String: Any] = ["selector":["foo":"bar"],
                                                   "sort": [["foo":"desc"]],
@@ -288,7 +288,7 @@ class FindDocumentOperationTests: XCTestCase {
         if let httpBody = httpBodyOpt {
             
             do {
-                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:NSObject]
+                let json = try JSONSerialization.jsonObject(with: httpBody, options: JSONSerialization.ReadingOptions()) as? [String:Any]
                 
                 let expected:[String:Any] = ["selector":["foo":"bar"]]
                 


### PR DESCRIPTION
## What
Within the findDocumentOperationTests, a few of the tests were attempting to downcast a result from jsonObject to [String: NSObject] however this was returning nil on Linux which was causing the tests to fail. Changing the casting to [String: Any] fixes this issue and is the change I've made in 4 of the tests. 

## How
Edited the test themselves to the new casting to [String: Any]

## Testing
Running the findDocumentOperationTests will test these changes, and on Linux they should now pass and still pass on Mac. 

## Issues
https://github.com/IBM-Swift/SwiftRuntime/issues/284
