### PR TITLE
Issue-285 [BulkDocsTests failure Changed casting from NSDictionary to…

### DIFF
--- a/Tests/SwiftCloudantTests/BulkDocsTests.swift
+++ b/Tests/SwiftCloudantTests/BulkDocsTests.swift
@@ -79,12 +79,12 @@ class BulkDocsTests : XCTestCase {
         XCTAssertEqual("POST", bulk.method)
         if let data = data {
             
-            let requestJson = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+            let requestJson = try JSONSerialization.jsonObject(with: data) as! [String: Any]
             
             
             let expected: [String: Any] = ["docs":[["hello":"world"],["foo":"bar"]], "new_edits":false, "all_or_nothing":true]
             
-            XCTAssertEqual(expected as NSDictionary, requestJson)
+            XCTAssertEqual(expected as NSDictionary, requestJson as NSDictionary)
         }
     }
    
@@ -101,10 +101,10 @@ class BulkDocsTests : XCTestCase {
         XCTAssertEqual("POST", bulk.method)
         if let data = data {
             
-            let requestJson = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+            let requestJson = try JSONSerialization.jsonObject(with: data) as! [String: Any]
             
             let expected: [String: Any] = ["docs":[["hello":"world"],["foo":"bar"]], "new_edits":false]
-            XCTAssertEqual(expected as NSDictionary, requestJson)
+            XCTAssertEqual(expected as NSDictionary, requestJson as NSDictionary)
         }
     }
     
@@ -121,10 +121,10 @@ class BulkDocsTests : XCTestCase {
         XCTAssertEqual("POST", bulk.method)
         if let data = data {
             
-            let requestJson = try JSONSerialization.jsonObject(with: data) as! NSDictionary
+            let requestJson = try JSONSerialization.jsonObject(with: data) as! [String: Any]
             
             let expected: [String: Any] = ["docs":[["hello":"world"],["foo":"bar"]], "all_or_nothing":true]
-            XCTAssertEqual(expected as NSDictionary, requestJson)
+            XCTAssertEqual(expected as NSDictionary, requestJson as NSDictionary)
         }
     }
     


### PR DESCRIPTION
… [String: Any]

Thanks for your hard work, please ensure all items are complete before opening.

- [ ] You have signed the CLA as per the instructions in [CONTRIBUTING.md](https://github.com/cloudant/swift-cloudant/blob/master/CONTRIBUTING.md#contributor-license-agreement)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGELOG.md](https://github.com/cloudant/swift-cloudant/blob/master/CHANGELOG.md)
- [ ] You have completed the PR template below:

## What
Some of BulkDocsTests are  crashing due to force downcast  of the result obtained after JSON Serialization  (Dictionary<AnyHashable,Any>) to NSDictionary.There is no implicit bridging available between Dictionary and NSDictionary on Linux 

## How
 Changed the casting from NSDictionary to [String: Any] 
## Testing

After the above suggested changes the tests are passing successfully on Linux

## Issues

https://github.com/IBM-Swift/SwiftRuntime/issues/285