### PR TITLE
Fix Warning with ViewPaging.State.

### DIFF
--- a/Source/SwiftCloudant/Operations/Views/ViewPaging.swift
+++ b/Source/SwiftCloudant/Operations/Views/ViewPaging.swift
@@ -261,7 +261,7 @@ public class ViewPager {
     /**
      A container for the current state of pagination
      */
-    private struct State {
+    fileprivate struct State {
         var lastEndKey: Any?
         var lastEndKeyDocID: String?
         


### PR DESCRIPTION
## What

Fix a warning in the ViewPager class.

## How

Change the access level of `ViewPager.State` to `fileprivate` from `private`

## Testing

No new tests, all tests pass and warning is not present in xcode 8.3.

## Issues

Fixes #151
