### PR TITLE
Workaround lack of Bundle(for:) on Linux

### DIFF
--- a/Source/SwiftCloudant/HTTP/URLSession.swift
+++ b/Source/SwiftCloudant/HTTP/URLSession.swift
@@ -457,18 +457,18 @@ internal class InterceptableSession: NSObject, URLSessionDelegate, URLSessionTas
         #else
             let platform = "Unknown";
         #endif
-        let frameworkBundle = Bundle(for: InterceptableSession.self)
-        var bundleDisplayName = frameworkBundle.object(forInfoDictionaryKey: "CFBundleName")
-        var bundleVersionString = frameworkBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString")
 
-        if bundleDisplayName == nil {
-            bundleDisplayName = "SwiftCloudant"
-        }
-        if bundleVersionString == nil {
-            bundleVersionString = "Unknown"
-        }
+        var bundleDisplayName: String = "SwiftCloudant"
+        var bundleVersionString: String = "Unknown"
 
-        return "\(bundleDisplayName!)/\(bundleVersionString!)/\(platform)/\(osVersion))"
+        #if !os(Linux)
+            // Bundle(for:) is not yet supported on Linux
+            let frameworkBundle = Bundle(for: InterceptableSession.self)
+            bundleDisplayName = frameworkBundle.object(forInfoDictionaryKey: "CFBundleName") as! String
+            bundleVersionString = frameworkBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
+        #endif
+
+        return "\(bundleDisplayName)/\(bundleVersionString)/\(platform)/\(osVersion))"
 
     }
 }

--- a/Source/SwiftCloudant/HTTP/URLSession.swift
+++ b/Source/SwiftCloudant/HTTP/URLSession.swift
@@ -458,8 +458,8 @@ internal class InterceptableSession: NSObject, URLSessionDelegate, URLSessionTas
             let platform = "Unknown";
         #endif
 
-        var bundleDisplayName: String = "SwiftCloudant"
-        var bundleVersionString: String = "Unknown"
+        var bundleDisplayName = "SwiftCloudant"
+        var bundleVersionString = "0.6.0"
 
         #if !os(Linux)
             // Bundle(for:) is not yet supported on Linux


### PR DESCRIPTION
As `Bundle(for:)` is not available on Linux, and is unlikely to be implemented in the short-term, work around this omission.