### PR TITLE
Import Dispatch explicitly

### DIFF
--- a/Tests/SwiftCloudantTests/InterceptableSessionTests.swift
+++ b/Tests/SwiftCloudantTests/InterceptableSessionTests.swift
@@ -15,7 +15,7 @@
 //  and limitations under the License.
 //
 
-
+import Dispatch
 import Foundation
 import XCTest
 @testable import SwiftCloudant

--- a/Tests/SwiftCloudantTests/TestHelpers.swift
+++ b/Tests/SwiftCloudantTests/TestHelpers.swift
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 //
 
+import Dispatch
 import Foundation
 import XCTest
 @testable import SwiftCloudant


### PR DESCRIPTION
On Linux, Dispatch must be imported explicitly.  Importing it on Darwin as well does no harm, so just add the `import Dispatch` to those files which use it.