### PR TITLE
Remove implicit bridging in tests

### DIFF
--- a/Tests/SwiftCloudantTests/BulkDocsTests.swift
+++ b/Tests/SwiftCloudantTests/BulkDocsTests.swift
@@ -84,7 +84,7 @@ class BulkDocsTests : XCTestCase {
             
             let expected: [String: Any] = ["docs":[["hello":"world"],["foo":"bar"]], "new_edits":false, "all_or_nothing":true]
             
-            XCTAssertEqual(expected as NSDictionary, requestJson as NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestJson))
         }
     }
    
@@ -104,7 +104,7 @@ class BulkDocsTests : XCTestCase {
             let requestJson = try JSONSerialization.jsonObject(with: data) as! [String: Any]
             
             let expected: [String: Any] = ["docs":[["hello":"world"],["foo":"bar"]], "new_edits":false]
-            XCTAssertEqual(expected as NSDictionary, requestJson as NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestJson))
         }
     }
     
@@ -124,7 +124,7 @@ class BulkDocsTests : XCTestCase {
             let requestJson = try JSONSerialization.jsonObject(with: data) as! [String: Any]
             
             let expected: [String: Any] = ["docs":[["hello":"world"],["foo":"bar"]], "all_or_nothing":true]
-            XCTAssertEqual(expected as NSDictionary, requestJson as NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestJson))
         }
     }
     

--- a/Tests/SwiftCloudantTests/CreateQueryIndexTests.swift
+++ b/Tests/SwiftCloudantTests/CreateQueryIndexTests.swift
@@ -94,7 +94,7 @@ public class CreateQueryIndexTests : XCTestCase {
         if let data = data {
             let json = try JSONSerialization.jsonObject(with: data)
             let expected: [String :Any] = ["type":"json", "index":["fields" : ["foo"]], "name" : "indexName", "ddoc":"ddoc"]
-            XCTAssertEqual(expected as NSDictionary , json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
         
     }
@@ -116,7 +116,7 @@ public class CreateQueryIndexTests : XCTestCase {
             let defaultField: [String: Any] = ["enabled": true, "analyzer": "english" ]
             let index: [String: Any] =   [ "selector": ["bar" : "foo"], "fields" : [["foo":"string"]], "default_field": defaultField]
             let expected: [String :Any] = ["type":"text","index": index, "name" : "indexName", "ddoc":"ddoc"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -130,7 +130,7 @@ public class CreateQueryIndexTests : XCTestCase {
         if let data = data {
             let json = try JSONSerialization.jsonObject(with: data)
             let expected: [String: Any] = ["type":"json", "index":["fields" : ["foo"]], "ddoc":"ddoc"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -144,7 +144,7 @@ public class CreateQueryIndexTests : XCTestCase {
         if let data = data {
             let json = try JSONSerialization.jsonObject(with: data)
             let expected: [String: Any] = ["type":"json", "index":["fields" : ["foo"]], "name":"indexName"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -161,7 +161,7 @@ public class CreateQueryIndexTests : XCTestCase {
             let defaultField: [String:Any] = ["enabled": true, "analyzer": "english" ]
             let index: [String: Any] = ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": defaultField ]
             let expected: [String: Any] = ["type":"text", "index" : index , "ddoc":"ddoc"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -178,7 +178,7 @@ public class CreateQueryIndexTests : XCTestCase {
             let defaultIndex:[String:Any] = ["enabled": true, "analyzer": "english" ]
             let index: [String: Any] = ["selector":["bar":"foo"], "default_field":defaultIndex ]
             let expected: [String: Any] = ["type":"text", "name": "indexName", "index" :index , "ddoc":"ddoc"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -195,7 +195,7 @@ public class CreateQueryIndexTests : XCTestCase {
             let defaultField: [String:Any] = ["enabled": true, "analyzer": "english" ]
             let index: [String:Any]  = ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": defaultField ]
             let expected: [String:Any] = ["type":"text", "index" :index , "name":"indexName"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -211,7 +211,7 @@ public class CreateQueryIndexTests : XCTestCase {
             let json = try JSONSerialization.jsonObject(with: data)
             let index: [String:Any] = ["selector":["bar":"foo"], "fields" : [["foo":"string"]], "default_field": ["enabled": true ]]
             let expected: [String: Any] = ["type":"text", "index" : index, "ddoc":"ddoc", "name": "indexName"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -227,7 +227,7 @@ public class CreateQueryIndexTests : XCTestCase {
             let json = try JSONSerialization.jsonObject(with: data)
             let index: [String: Any] = [ "selector":["bar":"foo"],"fields" : [["foo":"string"]], "default_field": ["analyzer": "english" ]]
             let expected: [String: Any] = ["type":"text", "index" : index, "ddoc":"ddoc", "name": "indexName"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     
@@ -244,7 +244,7 @@ public class CreateQueryIndexTests : XCTestCase {
             let defaultField:[String: Any] = ["enabled": true, "analyzer": "english" ]
             let index: [String: Any] = [ "fields" : [["foo":"string"]], "default_field": defaultField ]
             let expected: [String: Any] = ["type":"text", "index" : index,"name":"indexName", "ddoc":"ddoc"]
-            XCTAssertEqual(expected as NSDictionary, json as? NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json as! [AnyHashable: Any]))
         }
     }
     

--- a/Tests/SwiftCloudantTests/FindDocumentOperationTests.swift
+++ b/Tests/SwiftCloudantTests/FindDocumentOperationTests.swift
@@ -172,7 +172,7 @@ class FindDocumentOperationTests: XCTestCase {
                                 ]
                 
                 if let json = json {
-                    XCTAssertEqual(expected as NSDictionary, json as NSDictionary, "Expected: \(expected) but was \(json)")
+                    XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json), "Expected: \(expected) but was \(json)")
                } else {
                    XCTFail("Json could not be deseralised to the type [String:Any]")
                 }
@@ -205,7 +205,7 @@ class FindDocumentOperationTests: XCTestCase {
                 ]
                 
                 if let json = json {
-                    XCTAssertEqual(expected as NSDictionary, json as NSDictionary, "Expected: \(expected) but was \(json)")
+                    XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json), "Expected: \(expected) but was \(json)")
                 } else {
                     XCTFail("Json could not be deseralised to the type [String:Any]")
                 }
@@ -238,7 +238,7 @@ class FindDocumentOperationTests: XCTestCase {
                                                   ]
                 
                 if let json = json {
-                    XCTAssertEqual(expected as NSDictionary , json as NSDictionary, "Expected: \(expected) but was \(json)")
+                    XCTAssertEqual(NSDictionary(dictionary: expected) , NSDictionary(dictionary: json), "Expected: \(expected) but was \(json)")
                 } else {
                     XCTFail("Json could not be deseralised to the type [String:Any]")
                 }
@@ -293,7 +293,7 @@ class FindDocumentOperationTests: XCTestCase {
                 let expected:[String:Any] = ["selector":["foo":"bar"]]
                 
                 if let json = json {
-                    XCTAssertEqual(expected as NSDictionary, json as NSDictionary, "Expected: \(expected) but was \(json)")
+                    XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: json), "Expected: \(expected) but was \(json)")
                 } else {
                     XCTFail("Json could not be deseralised to the type [String:Any]")
                 }

--- a/Tests/SwiftCloudantTests/GetAllDocsTest.swift
+++ b/Tests/SwiftCloudantTests/GetAllDocsTest.swift
@@ -154,7 +154,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -181,7 +181,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -209,7 +209,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -239,7 +239,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -269,7 +269,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -298,7 +298,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -327,7 +327,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -371,7 +371,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -400,7 +400,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -429,7 +429,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -458,7 +458,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -486,7 +486,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -515,7 +515,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -544,7 +544,7 @@ class GetAllDocsTest: XCTestCase {
             if let requestData = requestData {
                 XCTAssertNotNil(requestData)
                 let expected:[String:[String]] = ["keys":["keys","keys"]]
-                XCTAssertEqual(expected as NSDictionary, requestData as NSDictionary)
+                XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: requestData))
                 
             }
         }
@@ -585,7 +585,7 @@ class GetAllDocsTest: XCTestCase {
         
         let allDocs = GetAllDocsOperation(databaseName: dbName, rowHandler: { doc in
             let expected:[String:String] = ["hello":"world"]
-            XCTAssertEqual(expected as NSDictionary, doc as NSDictionary)
+            XCTAssertEqual(NSDictionary(dictionary: expected), NSDictionary(dictionary: doc))
             rowHandler.fulfill()
         }) { response, info, error in
             

--- a/Tests/SwiftCloudantTests/ViewPagingTests.swift
+++ b/Tests/SwiftCloudantTests/ViewPagingTests.swift
@@ -79,7 +79,7 @@ class ViewPagingTests : XCTestCase {
                 if isFirst {
                     firstPage = page
                 } else {
-                    XCTAssertNotEqual(firstPage as NSDictionary, page as NSDictionary)
+                    XCTAssertNotEqual(NSDictionary(dictionary: firstPage), NSDictionary(dictionary: page))
                 }
                 
                 let ids = self.extractIDs(from: page)
@@ -140,7 +140,7 @@ class ViewPagingTests : XCTestCase {
                     isSecond = true
                     return .next
                 } else if isSecond {
-                    XCTAssertNotEqual(firstPage as NSDictionary, page as NSDictionary)
+                    XCTAssertNotEqual(NSDictionary(dictionary: firstPage), NSDictionary(dictionary: page))
                     isSecond = false
                     return .previous
                 } else {
@@ -190,7 +190,7 @@ class ViewPagingTests : XCTestCase {
                 if isFirst {
                     firstPage = page
                 } else {
-                    XCTAssertNotEqual(firstPage as NSDictionary, page as NSDictionary)
+                    XCTAssertNotEqual( NSDictionary(dictionary: firstPage), NSDictionary(dictionary: page))
                 }
                 
                 let ids = self.extractIDs(from: page)
@@ -251,7 +251,7 @@ class ViewPagingTests : XCTestCase {
                     isSecond = true
                     return .next
                 } else if isSecond {
-                    XCTAssertNotEqual(firstPage as NSDictionary, page as NSDictionary)
+                    XCTAssertNotEqual(NSDictionary(dictionary: firstPage), NSDictionary(dictionary: page))
                     isSecond = false
                     return .previous
                 } else {
@@ -314,7 +314,7 @@ class ViewPagingTests : XCTestCase {
                 
                 for row in rows {
                     XCTAssertFalse(previousRows.contains {
-                        ($0 as NSDictionary).isEqual(to: row as NSDictionary)
+                        NSDictionary(dictionary: $0).isEqual(to: row)
                     })
                 }
                 
@@ -413,7 +413,7 @@ class ViewPagingTests : XCTestCase {
             XCTAssertNotNil(page)
             XCTAssertNotNil(token)
             if let page = page {
-                XCTAssertEqual(previousRows as NSArray, page["rows"] as? NSArray )
+                XCTAssertEqual(NSArray(array: previousRows), NSArray(array: page["rows"] as! [Any]))
             }
             
             tokenPageExpectation.fulfill()
@@ -491,7 +491,7 @@ class ViewPagingTests : XCTestCase {
             XCTAssertNotNil(page)
             XCTAssertNotNil(token)
             if let page = page {
-                XCTAssertEqual(previousRows as NSArray, page["rows"] as? NSArray )
+                XCTAssertEqual(NSArray(array: previousRows),  NSArray(array: page["rows"] as! [Any] ))
             }
             
             tokenPageExpectation.fulfill()
@@ -553,7 +553,7 @@ class ViewPagingTests : XCTestCase {
             XCTAssertNotNil(page)
             XCTAssertNotNil(token)
             if let page = page {
-                XCTAssertEqual(previousRows as NSArray, page["rows"] as? NSArray )
+                XCTAssertEqual(NSArray(array: previousRows),  NSArray(array: page["rows"] as! [Any] ))
             }
             
             tokenPageExpectation.fulfill()
@@ -632,7 +632,7 @@ class ViewPagingTests : XCTestCase {
             XCTAssertNotNil(page)
             XCTAssertNotNil(token)
             if let page = page {
-                XCTAssertEqual(previousRows as NSArray, page["rows"] as? NSArray )
+                XCTAssertEqual(NSArray(array: previousRows),  NSArray(array: page["rows"] as! [Any] ))
             }
             
             tokenPageExpectation.fulfill()


### PR DESCRIPTION
Although Darwin platforms have automatic bridging between Foundation types such as `NSDictionary` and Swift types like `Dictionary`, this is unfortunately not supported on Linux.

Work around this by explicitly bridging instead.  Although this does create additional instances of Foundation classes on Darwin, this is OK as it's only in the tests so won't affect performance.