### PR TITLE
Crash in Cloudant tests due to httpAdditionalHeaders [382]

### DIFF
--- a/Source/SwiftCloudant/HTTP/URLSession.swift
+++ b/Source/SwiftCloudant/HTTP/URLSession.swift
@@ -166,7 +166,7 @@ internal class InterceptableSession: NSObject, URLSessionDelegate, URLSessionTas
     // URLSession instance when it is required.
     internal lazy var session: URLSession = { () -> URLSession in
         let config = URLSessionConfiguration.default
-        config.httpAdditionalHeaders = [("User-Agent" as NSString) as AnyHashable: InterceptableSession.userAgent()]
+        config.httpAdditionalHeaders = ["User-Agent" as AnyHashable: InterceptableSession.userAgent()]
         config.httpCookieAcceptPolicy = .onlyFromMainDocumentDomain
         config.httpCookieStorage = .shared
         


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [ ] You have signed the CLA as per the instructions in [CONTRIBUTING.md](https://github.com/cloudant/swift-cloudant/blob/master/CONTRIBUTING.md#contributor-license-agreement)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGELOG.md](https://github.com/cloudant/swift-cloudant/blob/master/CHANGELOG.md)
- [ ] You have completed the PR template below:

## What


/Source/SwiftCloudant/HTTP/URLSession.swift  is performing an explicit cast  from String to NSString as below which does not work on Linux due to which the test suite crashes on linux while processing the ```httpAdditionalHeaders``` by Swift Foundation .
``` config.httpAdditionalHeaders = [("User-Agent" as NSString) as AnyHashable: InterceptableSession.userAgent()]```.

Moreover, we don't need  explicit casting as the String itself   can be casted to AnyHashable .
## How

Removed  explicit casting to NSString
## Testing

Running the cloudant test-suite on Linux

## Issues

https://github.com/IBM-Swift/SwiftRuntime/issues/382
