### PR TITLE
Use CouchDBClient.version for user-agent string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
           - export PATH=${PWD}/swift-3.1.1-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
     - os: osx
       language: objective-c
-      osx_image: xcode8.3
+      osx_image: xcode9.2
       before_script:
         - brew install couchdb
         - brew services start couchdb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,7 @@ def buildAndTest(nodeLabel) {
       withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'clientlibs-test', usernameVariable: 'TEST_COUCH_USERNAME', passwordVariable: 'TEST_COUCH_PASSWORD']]) {
         withEnv(["TEST_COUCH_URL=https://clientlibs-test.cloudant.com"]) {
           sh 'swift build'
-          // Workaround Xcode 9 issues with 'swift test' command failing
-          sh 'swift package generate-xcodeproj'
-          sh 'xcodebuild -project SwiftCloudant.xcodeproj -scheme SwiftCloudant-Package test'
-          // sh 'swift test'
+          sh 'swift test'
         }
       }
   }

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:3.2
+
 //  Copyright (c) 2016 IBM Corp.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -8,6 +10,8 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 //
+
+
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,3 @@
-// swift-tools-version:3.1
 //  Copyright (c) 2016 IBM Corp.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/Source/SwiftCloudant/CouchClient.swift
+++ b/Source/SwiftCloudant/CouchClient.swift
@@ -73,7 +73,7 @@ public class CouchDBClient {
     internal let rootURL: URL
 
     // The version number of swift-cloudant, as a string
-    static let version = "0.7.0"
+    static let version = "0.7.1-SNAPSHOT"
 
     /**
      Creates a CouchDBClient instance.

--- a/Source/SwiftCloudant/CouchClient.swift
+++ b/Source/SwiftCloudant/CouchClient.swift
@@ -72,6 +72,9 @@ public class CouchDBClient {
     internal let password: String?
     internal let rootURL: URL
 
+    // The version number of swift-cloudant, as a string
+    static let version = "0.7.0"
+
     /**
      Creates a CouchDBClient instance.
 

--- a/Source/SwiftCloudant/HTTP/URLSession.swift
+++ b/Source/SwiftCloudant/HTTP/URLSession.swift
@@ -458,17 +458,7 @@ internal class InterceptableSession: NSObject, URLSessionDelegate, URLSessionTas
             let platform = "Unknown";
         #endif
 
-        var bundleDisplayName = "SwiftCloudant"
-        var bundleVersionString = "0.7.0"
-
-        #if !os(Linux)
-            // Bundle(for:) is not yet supported on Linux
-            let frameworkBundle = Bundle(for: InterceptableSession.self)
-            bundleDisplayName = frameworkBundle.object(forInfoDictionaryKey: "CFBundleName") as! String
-            bundleVersionString = frameworkBundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
-        #endif
-
-        return "\(bundleDisplayName)/\(bundleVersionString)/\(platform)/\(osVersion))"
+        return "SwiftCloudant/\(CouchDBClient.version)/\(platform)/\(osVersion))"
 
     }
 }

--- a/SwiftCloudant.podspec
+++ b/SwiftCloudant.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftCloudant"
-  s.version      = "0.7.0"
+  s.version      = "0.7.1-SNAPSHOT"
   s.summary      = "SwiftCloudant is a client library for  Apache CouchDB / IBM Cloudant from Swift 3"
 
   s.description  = <<-DESC


### PR DESCRIPTION
## What

Fix incorrect behaviour when fetching version number for user-agent string

## How

`Bundle(for:)` is not supported on Linux
(https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/Bundle.swift), and we don't expect it to be supported any time soon.

Instead, define the version number in CouchDBClient and hardcode the first part of the
user-agent as "SwiftCloudant".

## Testing

All existing tests pass

## TODO

Once merged, fix instructions in https://github.com/cloudant/cloudant-sync/blob/master/releasing-swift.md regarding version number updates.

## Issues

See #170