### PR TITLE
Revert to version 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ matrix:
           - sudo apt-get install -y build-essential git libcurl3 libblocksruntime-dev clang libicu-dev uuid-dev
           - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
           - gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
-          - wget https://swift.org/builds/swift-3.1.1-release/ubuntu1404/swift-3.1.1-RELEASE/swift-3.1.1-RELEASE-ubuntu14.04.tar.gz
-          - gunzip swift-3.1.1-RELEASE-ubuntu14.04.tar.gz
-          - tar -xvf swift-3.1.1-RELEASE-ubuntu14.04.tar
-          - export PATH=${PWD}/swift-3.1.1-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
+          - wget https://swift.org/builds/swift-4.0.3-release/ubuntu1404/swift-4.0.3-RELEASE/swift-4.0.3-RELEASE-ubuntu14.04.tar.gz
+          - gunzip swift-4.0.3-RELEASE-ubuntu14.04.tar.gz
+          - tar -xvf swift-4.0.3-RELEASE-ubuntu14.04.tar
+          - export PATH=${PWD}/swift-4.0.3-RELEASE-ubuntu14.04/usr/bin:"${PATH}"
     - os: osx
       language: objective-c
       osx_image: xcode9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Unreleased
 
-# 0.7.1 (2018-03-12)
-
-- [FIXED] Set the default swift language version to 3.2
+- [FIXED] Set the default Swift language version in the SwiftCloudant.podspec to 3.1
 - [FIXED] Fixed warning for non-exhaustive switch statement.
 
 # 0.7.0 (2017-04-10)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:3.2
+// swift-tools-version:3.1
 
 //  Copyright (c) 2016 IBM Corp.
 //

--- a/SwiftCloudant.podspec
+++ b/SwiftCloudant.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.source = { :git => "https://github.com/cloudant/swift-cloudant.git", :tag => s.version.to_s}
   s.source_files  = "Classes", "Source/**/*.swift"
-  s.swift_version = '3.2'
+  s.swift_version = '3.1'
 end


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/swift-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/cloudant/swift-cloudant/blob/master/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

Reverted the Swift version to 3.1

## How

There is no "3.2" tools version for Linux so using 3.2 prevents `swift` CLI commands from executing on that platform (even when using 4.x releases of Swift). Although not everything works on Linux, it is better to have the stuff that works keep working rather than having nothing work with a 3.2 change.

Also updated the Linux Swift download to a more newly released version which allows SwiftCloudant to compile cleanly and the tests to execute (even though the runtime regression that prevents the `GetChanges` tests passing is still present.

## Testing

Existing macOS tests pass, Linux tests run and the expected ones pass.

## Issues

N/A
