### PR TITLE
Proposed 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# Unreleased
+# 0.8.0 (2018-03-20)
 
-- [FIXED] Set the default Swift language version in the SwiftCloudant.podspec to 3.1
+- [NEW] Runs on Swift 4.x on Linux with some limitations (see note).
+- [FIXED] Set the default Swift language version in the SwiftCloudant.podspec to 3.1.
 - [FIXED] Fixed warning for non-exhaustive switch statement.
+- [NOTE] The `GetChangesOperation` is not currently supported by the Linux platform,
+  see [issue #176](https://github.com/cloudant/swift-cloudant/issues/176).
 
 # 0.7.0 (2017-04-10)
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ on a "best effort" basis.
 
 ### Platforms
 
-Currently Swift Cloudant suppports:
+Currently Swift Cloudant supports:
 
 - macOS
+- Linux (with Swift 4.x; known [issue #176](https://github.com/cloudant/swift-cloudant/issues/176) with `GetChangesOperation`).
 
 
 Swift Cloudant is unsupported on:
@@ -46,9 +47,6 @@ Swift Cloudant is unsupported on:
 - iOS (should work, but hasn't been tested)
 - tvOS
 - watchOS
-- Linux (see issue [#121][linux] for progress updates)
-
-[linux]:https://github.com/cloudant/swift-cloudant/issues/121
 
 ## Using in your project
 

--- a/Source/SwiftCloudant/CouchClient.swift
+++ b/Source/SwiftCloudant/CouchClient.swift
@@ -73,7 +73,7 @@ public class CouchDBClient {
     internal let rootURL: URL
 
     // The version number of swift-cloudant, as a string
-    static let version = "0.7.1-SNAPSHOT"
+    static let version = "0.8.0"
 
     /**
      Creates a CouchDBClient instance.

--- a/SwiftCloudant.podspec
+++ b/SwiftCloudant.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftCloudant"
-  s.version      = "0.7.1-SNAPSHOT"
+  s.version      = "0.8.0"
   s.summary      = "SwiftCloudant is a client library for  Apache CouchDB / IBM Cloudant from Swift 3"
 
   s.description  = <<-DESC


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/swift-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/cloudant/swift-cloudant/blob/master/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

Proposed 0.8.0 release

## How

# 0.8.0 (2018-03-16)

- [NEW] Runs on Swift 4.x on Linux with some limitations (see note).
- [FIXED] Set the default Swift language version in the SwiftCloudant.podspec to 3.1.
- [FIXED] Fixed warning for non-exhaustive switch statement.
- [NOTE] The `GetChangesOperation` is not currently supported by the Linux platform,
  see [issue #176](https://github.com/cloudant/swift-cloudant/issues/176).

## Testing

N/A - release

## Issues

https://github.com/cloudant/swift-cloudant/milestone/8
