### PR TITLE
Proposed 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-# Unreleased
-
+# 0.9.0 (2019-04-15)
+- [FIXED] Fixed scope of `Operation.Error` to be exposed as public.
+- [BREAKING CHANGE] Projects using older Swift tool and language versions will not work with versions newer than 0.8.0.
 - [UPGRADED] Minimum Swift language version to 4.2.
 - [UPGRADED] Swift tools version and package manifest to version 5.0.
-- [BREAKING CHANGE] Projects using older Swift tool and language versions will not work with versions newer than 0.8.0.
-- [FIXED] Fixed scope of `Operation.Error` to be exposed as public.
 
 # 0.8.0 (2018-03-20)
 

--- a/Source/SwiftCloudant/CouchClient.swift
+++ b/Source/SwiftCloudant/CouchClient.swift
@@ -73,7 +73,7 @@ public class CouchDBClient {
     internal let rootURL: URL
 
     // The version number of swift-cloudant, as a string
-    static let version = "0.8.1-SNAPSHOT"
+    static let version = "0.9.0"
 
     /**
      Creates a CouchDBClient instance.

--- a/SwiftCloudant.podspec
+++ b/SwiftCloudant.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftCloudant"
-  s.version      = "0.8.1-SNAPSHOT"
+  s.version      = "0.9.0"
   s.summary      = "SwiftCloudant is a client library for  Apache CouchDB / IBM Cloudant"
 
   s.description  = <<-DESC


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/swift-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/cloudant/swift-cloudant/blob/master/CHANGELOG.md)
- [x] You have completed the PR template below:

## What

Proposed 0.9.0 release

## How

# 0.9.0 (2019-04-15)

- [UPGRADED] Minimum Swift language version to 4.2.
- [UPGRADED] Swift tools version and package manifest to version 5.0.
- [BREAKING CHANGE] Projects using older Swift tool and language versions will not work with versions newer than 0.8.0.
- [FIXED] Fixed scope of `Operation.Error` to be exposed as public.

## Testing

N/A - release

## Issues

https://github.com/cloudant/swift-cloudant/milestone/9